### PR TITLE
chore: update root package.json name to @deessejs/core

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,13 +1,14 @@
-# Package Template
+# @deessejs/core
 
-This is a TypeScript monorepo template using pnpm workspaces, turbo, vitest, husky, and changesets.
+TypeScript monorepo for `@deessejs/core` - Type-safe error handling library using pnpm workspaces, turbo, vitest, husky, and changesets.
 
 ## Project Structure
 
 ```
 .
 ├── packages/              # Workspace packages
-│   └── example/          # Example package
+│   └── core/             # Main @deessejs/core package
+├── examples/             # Usage examples
 ├── .github/workflows/    # GitHub Actions
 ├── .husky/              # Git hooks
 ├── turbo.json           # Turbo configuration

--- a/package.json
+++ b/package.json
@@ -1,14 +1,16 @@
 {
-  "name": "@nesalia/template-monorepo-ts",
+  "name": "@deessejs/core",
   "version": "0.1.7",
-  "description": "TypeScript monorepo template with vitest, turbo, husky, and changesets",
+  "private": true,
+  "description": "Monorepo for @deessejs/core - Type-safe error handling for TypeScript",
   "scripts": {
     "build": "turbo build",
     "dev": "turbo dev",
     "lint": "turbo lint",
     "typecheck": "turbo typecheck",
     "test": "turbo test",
-    "clean": "turbo clean"
+    "clean": "turbo clean",
+    "prepare": "husky"
   },
   "devDependencies": {
     "@changesets/cli": "^2.27.0",
@@ -27,13 +29,21 @@
     "baseBranch": "main",
     "changelog": false,
     "commit": false,
-    "fixed": [],
+    "fixed": [
+      "@deessejs/core"
+    ],
     "linked": [],
     "access": "restricted"
   },
-  "nesalia": {
-    "id": "monorepo-ts",
-    "displayName": "Monorepo TS",
-    "description": "Monorepo TS - TypeScript monorepo with vitest, turbo, husky, and changesets"
-  }
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nesalia-inc/core.git"
+  },
+  "keywords": [
+    "typescript",
+    "functional-programming",
+    "error-handling",
+    "monad"
+  ],
+  "license": "MIT"
 }


### PR DESCRIPTION
## Summary
- Rename root package from `@nesalia/template-monorepo-ts` to `@deessejs/core`
- Add `private: true` to prevent accidental publish to npm
- Add repository, keywords, and license fields
- Add `@deessejs/core` to changesets fixed packages
- Update CLAUDE.md to reflect actual project structure

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>