### PR TITLE
fix: resolve lint errors in test files

### DIFF
--- a/packages/core/tests/retry.test.ts
+++ b/packages/core/tests/retry.test.ts
@@ -62,7 +62,7 @@ describe("Retry", () => {
     });
 
     it("should apply jitter when enabled", () => {
-      let jitterValue = 0.5;
+      const jitterValue = 0.5;
       vi.spyOn(Math, "random").mockImplementation(() => jitterValue);
 
       let attempts = 0;

--- a/packages/core/tests/sleep.test.ts
+++ b/packages/core/tests/sleep.test.ts
@@ -93,7 +93,6 @@ describe("Sleep", () => {
 
     it("should resolve before abort when signal is provided", async () => {
       const controller = new AbortController();
-      const start = Date.now();
       const sleepPromise = sleepWithSignal(50, controller.signal);
 
       // Abort after a short delay


### PR DESCRIPTION
## Summary
- Use const instead of let for jitterValue in retry.test.ts
- Remove unused start variable in sleep.test.ts

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>