### PR TITLE
fix: escape generic types in MDX documentation

### DIFF
--- a/apps/web/content/docs/async-result.mdx
+++ b/apps/web/content/docs/async-result.mdx
@@ -15,8 +15,8 @@ type AsyncResult<T, E = Error> = Promise<AsyncResultInner<T, E>>;
 type AsyncResultInner<T, E> = AsyncOk<T> | AsyncErr<E>;
 ```
 
-- **AsyncOk<T>** - Successful async result with value `T`
-- **AsyncErr<E>** - Failed async result with error `E`
+- **`AsyncOk<T>`** - Successful async result with value `T`
+- **`AsyncErr<E>`** - Failed async result with error `E`
 
 ## Creating an AsyncResult
 

--- a/apps/web/content/docs/maybe.mdx
+++ b/apps/web/content/docs/maybe.mdx
@@ -13,7 +13,7 @@ The `Maybe` type represents an optional value - it can be either `Some` (has a v
 type Maybe<T> = Some<T> | None;
 ```
 
-- **Some<T>** - Represents a present value of type `T`
+- **`Some<T>`** - Represents a present value of type `T`
 - **None** - Represents the absence of a value
 
 ## Creating a Maybe

--- a/apps/web/content/docs/outcome.mdx
+++ b/apps/web/content/docs/outcome.mdx
@@ -13,9 +13,9 @@ The `Outcome` type provides rich error handling with three variants: `Success` f
 type Outcome<T, C = unknown, E = unknown> = Success<T> | Cause<C> | Exception<E>;
 ```
 
-- **Success<T>** - Represents a successful operation with value `T`
-- **Cause<C>** - Represents an expected error with cause data `C`
-- **Exception<E>** - Represents an unexpected error with exception data `E`
+- **`Success<T>`** - Represents a successful operation with value `T`
+- **`Cause<C>`** - Represents an expected error with cause data `C`
+- **`Exception<E>`** - Represents an unexpected error with exception data `E`
 
 ## Creating an Outcome
 

--- a/apps/web/content/docs/result.mdx
+++ b/apps/web/content/docs/result.mdx
@@ -13,8 +13,8 @@ The `Result` type represents a value that can be either a success (`Ok`) or a fa
 type Result<T, E> = Ok<T> | Err<E>;
 ```
 
-- **Ok<T>** - Represents a successful result containing a value of type `T`
-- **Err<E>** - Represents a failure containing an error of type `E`
+- **`Ok<T>`** - Represents a successful result containing a value of type `T`
+- **`Err<E>`** - Represents a failure containing an error of type `E`
 
 ## Creating a Result
 

--- a/apps/web/content/docs/try.mdx
+++ b/apps/web/content/docs/try.mdx
@@ -13,8 +13,8 @@ The `Try` type wraps synchronous functions that might throw exceptions. It captu
 type Try<T, E = Error> = TrySuccess<T> | TryFailure<E>;
 ```
 
-- **TrySuccess<T>** - Represents a successful execution with value `T`
-- **TryFailure<E>** - Represents a failure with error `E`
+- **`TrySuccess<T>`** - Represents a successful execution with value `T`
+- **`TryFailure<E>`** - Represents a failure with error `E`
 
 ## Creating a Try
 


### PR DESCRIPTION
## Summary
- Use backticks instead of bold for type names with generics
- Fixes MDX parsing error where `<T>` was interpreted as HTML tag

## Files Changed
- result.mdx
- maybe.mdx
- outcome.mdx
- try.mdx
- async-result.mdx

Co-Authored-By: Claude Opus 4.6 <noreply@anthropic.com>