### PR TITLE
docs: remove H1 headings from MDX files

### DIFF
--- a/apps/web/content/docs/async-result.mdx
+++ b/apps/web/content/docs/async-result.mdx
@@ -3,8 +3,6 @@ title: AsyncResult
 description: Async operations with type-safe error handling
 ---
 
-# AsyncResult
-
 The `AsyncResult` type handles asynchronous operations with proper error typing. It wraps promises and provides the same functional patterns as `Result`.
 
 ## Overview

--- a/apps/web/content/docs/conversions.mdx
+++ b/apps/web/content/docs/conversions.mdx
@@ -3,8 +3,6 @@ title: Conversions
 description: Convert between Result, Maybe, Try, and Outcome types
 ---
 
-# Conversions
-
 The library provides utilities to convert between different types: `Result`, `Maybe`, `Try`, and `Outcome`.
 
 ## Maybe to Result

--- a/apps/web/content/docs/examples.mdx
+++ b/apps/web/content/docs/examples.mdx
@@ -3,8 +3,6 @@ title: Examples
 description: Real-world usage examples for @deessejs/core
 ---
 
-# Examples
-
 Practical examples demonstrating how to use `@deessejs/core` in real applications.
 
 ## HTTP API with Retry

--- a/apps/web/content/docs/faq.mdx
+++ b/apps/web/content/docs/faq.mdx
@@ -3,8 +3,6 @@ title: FAQ
 description: Frequently asked questions about @deessejs/core
 ---
 
-# Frequently Asked Questions
-
 ## General
 
 ### What is @deessejs/core?

--- a/apps/web/content/docs/index.mdx
+++ b/apps/web/content/docs/index.mdx
@@ -3,8 +3,6 @@ title: Introduction
 description: Type-safe error handling for TypeScript with Result, Maybe, Try, Outcome, and AsyncResult monads
 ---
 
-# @deessejs/core
-
 **@deessejs/core** is a TypeScript library that provides functional programming patterns for type-safe error handling. It offers zero-runtime-dependency monads with a clean, composable API.
 
 ## Why @deessejs/core?

--- a/apps/web/content/docs/installation.mdx
+++ b/apps/web/content/docs/installation.mdx
@@ -3,8 +3,6 @@ title: Installation
 description: How to install and set up @deessejs/core in your project
 ---
 
-# Installation
-
 ## Package Manager
 
 Install `@deessejs/core` using your preferred package manager:

--- a/apps/web/content/docs/maybe.mdx
+++ b/apps/web/content/docs/maybe.mdx
@@ -3,8 +3,6 @@ title: Maybe
 description: Handle optional values with Some and None
 ---
 
-# Maybe
-
 The `Maybe` type represents an optional value - it can be either `Some` (has a value) or `None` (no value). It's perfect for handling values that might be null or undefined.
 
 ## Overview

--- a/apps/web/content/docs/outcome.mdx
+++ b/apps/web/content/docs/outcome.mdx
@@ -3,8 +3,6 @@ title: Outcome
 description: Rich error handling with Success, Cause, and Exception
 ---
 
-# Outcome
-
 The `Outcome` type provides rich error handling with three variants: `Success` for successful operations, `Cause` for expected/business errors, and `Exception` for unexpected system errors.
 
 ## Overview

--- a/apps/web/content/docs/result.mdx
+++ b/apps/web/content/docs/result.mdx
@@ -3,8 +3,6 @@ title: Result
 description: Type-safe success/failure handling with typed errors
 ---
 
-# Result
-
 The `Result` type represents a value that can be either a success (`Ok`) or a failure (`Err`). It's the primary type for explicit error handling in your applications.
 
 ## Overview

--- a/apps/web/content/docs/retry.mdx
+++ b/apps/web/content/docs/retry.mdx
@@ -3,8 +3,6 @@ title: Retry
 description: Retry utilities for resilient operations
 ---
 
-# Retry
-
 The `retry` utilities provide resilient patterns for handling transient failures. They automatically retry failed operations with configurable backoff strategies.
 
 ## retry - Synchronous Retry

--- a/apps/web/content/docs/sleep.mdx
+++ b/apps/web/content/docs/sleep.mdx
@@ -3,8 +3,6 @@ title: Sleep
 description: Async sleep and timeout utilities
 ---
 
-# Sleep
-
 The `sleep` utility provides asynchronous delay functionality, essential for retry mechanisms, rate limiting, and testing.
 
 ## sleep - Basic Delay

--- a/apps/web/content/docs/try.mdx
+++ b/apps/web/content/docs/try.mdx
@@ -3,8 +3,6 @@ title: Try
 description: Wrap synchronous functions that might throw exceptions
 ---
 
-# Try
-
 The `Try` type wraps synchronous functions that might throw exceptions. It captures the result or the error without using try-catch blocks.
 
 ## Overview


### PR DESCRIPTION
## Summary
- Remove H1 headings from all MDX documentation files
- Titles are now generated automatically from frontmatter metadata

🤖 Generated with [Claude Code](https://claude.com/claude-code)