### PR TITLE
fix: restore MINIMAX environment variables

### DIFF
--- a/.github/workflows/comment-response.yml
+++ b/.github/workflows/comment-response.yml
@@ -121,7 +121,11 @@ jobs:
             --max-turns 30
 
         env:
-          ANTHROPIC_API_KEY: ${{ secrets.MINIMAX_API_KEY }}
+          ANTHROPIC_BASE_URL: https://api.minimax.io/anthropic
+          ANTHROPIC_AUTH_TOKEN: ${{ secrets.MINIMAX_API_KEY }}
+          ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.5
+          ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.5
+          ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.5
 
       - name: Success
         if: steps.mention-check.outputs.should_respond == 'true'


### PR DESCRIPTION
## Summary

Restore MINIMAX environment variables for the workflow.

## Changes

- ANTHROPIC_BASE_URL: https://api.minimax.io/anthropic
- ANTHROPIC_AUTH_TOKEN: ${{ secrets.MINIMAX_API_KEY }}
- ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.5
- ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.5
- ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.5

🤖 Generated with [Claude Code](https://claude.com/claude-code)