### PR TITLE
fix: use nesalia-inc/marty-action instead of claude-code-action

### DIFF
--- a/.github/workflows/comment-response.yml
+++ b/.github/workflows/comment-response.yml
@@ -73,9 +73,9 @@ jobs:
           app-id: ${{ secrets.MARTY_APP_ID }}
           private-key: ${{ secrets.MARTY_APP_PRIVATE_KEY }}
 
-      - name: Run Claude Code
+      - name: Run Marty
         if: steps.mention-check.outputs.should_respond == 'true' && steps.already-responded.outputs.already_done != 'true'
-        uses: anthropics/claude-code-action@v1
+        uses: nesalia-inc/marty-action@1.0.0
         with:
           github_token: ${{ steps.marty-token.outputs.token }}
           prompt: |


### PR DESCRIPTION
## Summary

Fix to use the same action as pr-review.yml which works correctly.

## Changes

- Changed from `anthropics/claude-code-action@v1` to `nesalia-inc/marty-action@1.0.0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)