### PR TITLE
fix: remove invalid members permission

### DIFF
--- a/.github/workflows/comment-response.yml
+++ b/.github/workflows/comment-response.yml
@@ -15,7 +15,6 @@ permissions:
   contents: read
   issues: write
   pull-requests: write
-  members: read
 
 jobs:
   respond:


### PR DESCRIPTION
## Summary

Remove invalid `members: read` permission from workflow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)