### PR TITLE
fix: allow PR review for Marty-created PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,6 +12,8 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
+    # Allow both human and bot (Marty) triggered runs
+    if: ${{ github.event.sender.type == 'User' || github.event.sender.login == 'marty-action[bot]' }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Allow the PR review workflow to run when triggered by marty-action bot.

This enables Marty to have its implementation PRs reviewed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)