### PR TITLE
feat: add status reactions to workflows

### DIFF
--- a/.github/workflows/agent-development.yml
+++ b/.github/workflows/agent-development.yml
@@ -409,9 +409,9 @@ jobs:
         if: success()
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
-          # Remove eyes reaction
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove eyes reaction from this workflow (user ID 41898282 is marty-action)
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions \
@@ -425,9 +425,9 @@ jobs:
         if: failure()
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
-          # Remove eyes reaction
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove eyes reaction from this workflow
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions \

--- a/.github/workflows/comment-response.yml
+++ b/.github/workflows/comment-response.yml
@@ -47,8 +47,8 @@ jobs:
           AUTHOR="${{ github.event.comment.user.login }}"
           REPO="${{ github.repository }}"
 
-          # Count runs in last 1 minute for this author
-          RUN_COUNT=$(gh api repos/$REPO/actions/runs --jq '.workflow_runs[] | select(.head_branch == "main") | select(.created_at > now - 60)' 2>/dev/null | grep -c "id" || echo "0")
+          # Count runs in last 1 minute
+          RUN_COUNT=$(gh api repos/$REPO/actions/runs?per_page=100 --jq '[.workflow_runs[] | select(.created_at > now - 60)] | length' 2>/dev/null || echo "0")
 
           # Allow max 20 runs per minute per user
           if [ "$RUN_COUNT" -ge 20 ]; then
@@ -284,9 +284,9 @@ jobs:
         if: success() && steps.mention-check.outputs.should_respond == 'true' && steps.rate-limit.outputs.rate_limited != 'true'
         run: |
           COMMENT_ID="${{ github.event.comment.id }}"
-          # First remove the eyes reaction, then add check mark
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove the eyes reaction added by this workflow (user ID 41898282 is marty-action)
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \
@@ -300,9 +300,9 @@ jobs:
         if: failure() && steps.mention-check.outputs.should_respond == 'true' && steps.rate-limit.outputs.rate_limited != 'true'
         run: |
           COMMENT_ID="${{ github.event.comment.id }}"
-          # First remove the eyes reaction, then add x
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove the eyes reaction added by this workflow
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/comments/$COMMENT_ID/reactions \

--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -181,9 +181,9 @@ jobs:
         if: success()
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
-          # Remove eyes reaction
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove eyes reaction from this workflow (user ID 41898282 is marty-action)
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions \
@@ -197,9 +197,9 @@ jobs:
         if: failure()
         run: |
           ISSUE_NUMBER="${{ github.event.issue.number }}"
-          # Remove eyes reaction
-          REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[].id' 2>/dev/null)
-          for reaction_id in $REACTIONS; do
+          # Only remove eyes reaction from this workflow
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
             gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
           done
           gh api repos/${{ github.repository }}/issues/$ISSUE_NUMBER/reactions \

--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -27,6 +27,16 @@ jobs:
           app-id: ${{ secrets.MARTY_APP_ID }}
           private-key: ${{ secrets.MARTY_APP_PRIVATE_KEY }}
 
+      # Add reaction to show review started
+      - name: Add eyes reaction
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"content":"eyes"}' \
+            2>/dev/null || echo "Reaction failed"
+
       - name: Run Marty PR Review
         uses: nesalia-inc/marty-action@1.0.0
         with:
@@ -96,3 +106,35 @@ jobs:
           ANTHROPIC_DEFAULT_SONNET_MODEL: MiniMax-M2.5
           ANTHROPIC_DEFAULT_HAIKU_MODEL: MiniMax-M2.5
           ANTHROPIC_DEFAULT_OPUS_MODEL: MiniMax-M2.5
+
+      # Add reaction to show review complete
+      - name: Add success reaction
+        if: success()
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          # Only remove eyes reaction from this workflow (user ID 41898282 is marty-action)
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
+            gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
+          done
+          gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"content":"white_check_mark"}' \
+            2>/dev/null || echo "Failed to add reaction"
+
+      # Add reaction to show error
+      - name: Add error reaction
+        if: failure()
+        run: |
+          PR_NUMBER="${{ github.event.pull_request.number }}"
+          # Only remove eyes reaction from this workflow
+          EYES_REACTIONS=$(gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions --jq '.[] | select(.user.id == 41898282 and .content == "eyes").id' 2>/dev/null)
+          for reaction_id in $EYES_REACTIONS; do
+            gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions/$reaction_id -X DELETE 2>/dev/null || true
+          done
+          gh api repos/${{ github.repository }}/issues/$PR_NUMBER/reactions \
+            -X POST \
+            -H "Accept: application/vnd.github+json" \
+            -d '{"content":"x"}' \
+            2>/dev/null || echo "Failed to add reaction"


### PR DESCRIPTION
## Summary

Add automatic status reactions to workflows:

- 👀 (eyes) - When processing starts
- ✅ (white check mark) - On success  
- ❌ (x) - On failure

Reactions are added to:
- Issue comments for comment-response workflow
- Issues for triage and development workflows
- PRs for review workflow

## Fixes from Review

1. **Race condition fixed**: Now only removes eyes reaction from marty-action (user ID 41898282) instead of all reactions
2. **Rate limiting fixed**: Corrected jq syntax for counting workflow runs
3. **Added reactions to pr-review.yml**: Now consistent with other workflows

## Test Plan

- [ ] Verify reactions appear correctly on new issues/comments/PRs

🤖 Generated with [Claude Code](https://claude.com/claude-code)