### PR TITLE
fix: skip PR review for marty-action created PRs

### DIFF
--- a/.github/workflows/pr-review.yml
+++ b/.github/workflows/pr-review.yml
@@ -12,8 +12,8 @@ permissions:
 jobs:
   review:
     runs-on: ubuntu-latest
-    # Allow both human and bot (Marty) triggered runs
-    if: ${{ github.event.sender.type == 'User' || github.event.sender.login == 'marty-action[bot]' }}
+    # Allow human-triggered runs and skip PRs created by marty-action (self-review)
+    if: ${{ github.event.sender.type == 'User' && github.event.pull_request.user.login != 'marty-action' }}
     steps:
       - name: Checkout PR branch
         uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

Prevent marty-action from reviewing its own PRs to avoid the "non-human actor" error.

## Changes

- Update the condition to skip PRs created by marty-action
- Now only reviews PRs from human users

🤖 Generated with [Claude Code](https://claude.com/claude-code)