### PR TITLE
fix: resolve git merge conflicts in api.mdx

### DIFF
--- a/apps/web/content/docs/reference/api.mdx
+++ b/apps/web/content/docs/reference/api.mdx
@@ -98,22 +98,15 @@ This is a minimal API reference. For detailed explanations, see the Guides and C
 
 ```typescript
 interface RetryOptions {
-<<<<<<< HEAD
   attempts?: number;        // Number of attempts (default: 3)
   delay?: number;          // Initial delay in ms (default: 1000)
   backoff?: "exponential" | "linear" | "constant" | ((attempt: number, delay: number) => number);
-=======
-  attempts?: number;      // Default: 3
-  delay?: number;         // Initial delay in ms, default: 1000
-  backoff?: "exponential" | "linear" | "constant";
->>>>>>> 5c98621aec8c6f639645434c4db208f29d0df90b
   predicate?: (error: Error) => boolean;
   onRetry?: (error: Error, attempt: number) => void;
   jitter?: boolean;
 }
 ```
 
-<<<<<<< HEAD
 ### ErrorOptions
 
 ```typescript
@@ -145,7 +138,7 @@ type ErrorGroup = {
   readonly exceptions: readonly Error[];
 };
 ```
-=======
+
 ## Quick Lookup
 
 Looking for something specific?
@@ -158,4 +151,3 @@ Looking for something specific?
 - **Advanced error handling** → Use `error()` + `exceptionGroup()` (Python-inspired)
 
 See [Choosing a Type](/docs/concepts/choosing-type) for detailed guidance.
->>>>>>> 5c98621aec8c6f639645434c4db208f29d0df90b


### PR DESCRIPTION
## Summary

Resolve leftover git merge conflict markers in `apps/web/content/docs/reference/api.mdx` that were causing the build to fail.

## Changes

- Removed `<<<<<<< HEAD`, `=======`, and `>>>>>>> 5c98621...` merge markers
- Kept the correct content from both sides of the conflict

🤖 Generated with [Claude Code](https://claude.com/claude-code)