### PR TITLE
fix: add version bump and build to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,12 @@ jobs:
       - name: Install dependencies
         run: pnpm install
 
+      - name: Version bump
+        run: pnpm release
+
+      - name: Build
+        run: pnpm build
+
       - name: Publish to npm
         run: pnpm npm publish --access public
         env:


### PR DESCRIPTION
## Summary

Fix the release workflow to properly use changesets for version bumping.

## Changes

- Add `pnpm release` step to bump versions from changesets before publishing
- Add `pnpm build` step to build the package before publishing

## Test plan

- [ ] Verify workflow works correctly when tag is pushed

🤖 Generated with [Claude Code](https://claude.com/claude-code)