### PR TITLE
feat: implement pipe() for linear composition

### DIFF
--- a/packages/core/src/conversions.ts
+++ b/packages/core/src/conversions.ts
@@ -37,3 +37,42 @@ export const toMaybeFromResult = <T, E>(result: Result<T, E>): Maybe<T> =>
  */
 export const fromUndefinedable = <T>(value: T | undefined): Maybe<T> =>
   value === undefined ? none() : some(value as NonNullable<T>);
+
+/**
+ * Converts a nullable value directly to Result in one step.
+ * Shorthand for combining fromNullable and toResult.
+ *
+ * @param value - The value that may be null or undefined
+ * @param onNull - Error factory to call when value is null/undefined
+ * @returns Ok<NonNullable<T>> if value is not null/undefined, Err<E> otherwise
+ *
+ * @example
+ * import { resultFromNullable } from '@deessejs/core';
+ *
+ * const user = resultFromNullable(db.find(id), () => 'NOT_FOUND');
+ * const port = resultFromNullable(parseInt(env.PORT), () => 'INVALID_PORT');
+ */
+export const resultFromNullable = <T, E>(
+  value: T | null | undefined,
+  onNull: () => E
+): Result<NonNullable<T>, E> =>
+  value == null ? err(onNull()) : ok(value as NonNullable<T>);
+
+/**
+ * Wraps a throwing function in a Result.
+ *
+ * @param fn - The function that may throw
+ * @returns Ok<T> with the return value, Err<Error> if the function throws
+ *
+ * @example
+ * import { resultFromThrowable } from '@deessejs/core';
+ *
+ * const data = resultFromThrowable(() => JSON.parse(jsonString));
+ */
+export const resultFromThrowable = <T>(fn: () => T): Result<T, Error> => {
+  try {
+    return ok(fn());
+  } catch (e) {
+    return err(e instanceof Error ? e : new Error(String(e)));
+  }
+};

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -117,8 +117,13 @@ export {
   toResult,
   toMaybeFromResult,
   fromUndefinedable,
+  resultFromNullable,
+  resultFromThrowable,
 } from "./conversions.js";
 export type { ToResultOptions } from "./conversions.js";
+
+// Pipe & Flow
+export { pipe, flow } from "./pipe.js";
 
 // Error System
 export type { Error, ErrorGroup, ErrorOptions } from "./error.js";

--- a/packages/core/src/pipe.ts
+++ b/packages/core/src/pipe.ts
@@ -1,0 +1,57 @@
+/**
+ * Pipe and Flow utilities for functional composition
+ */
+
+/**
+ * Pipes a value through a sequence of functions.
+ * Reads left-to-right, applying each function to the result of the previous.
+ *
+ * @param value - The initial value
+ * @param fns - The functions to apply in sequence
+ * @returns The final result after applying all functions
+ *
+ * @example
+ * import { pipe, map, getOrElse } from '@deessejs/core';
+ *
+ * const result = pipe(
+ *   "hello",
+ *   s => s.toUpperCase(),
+ *   s => s + "!",
+ * );
+ * // result: "HELLO!"
+ */
+export const pipe = (value: unknown, ...fns: Array<(arg: unknown) => unknown>): unknown =>
+  fns.reduce((acc, fn) => fn(acc), value);
+
+/**
+ * Creates a reusable function that composes multiple functions.
+ * Unlike pipe, flow returns a function that can be called later with an initial value.
+ *
+ * @param fns - The functions to compose
+ * @returns A new function that applies all functions in sequence
+ *
+ * @example
+ * import { flow, map, getOrElse } from '@deessejs/core';
+ *
+ * const processString = flow(
+ *   (s: string) => s.toUpperCase(),
+ *   (s: string) => s + "!"
+ * );
+ *
+ * processString("hello"); // "HELLO!"
+ * processString("world"); // "WORLD!"
+ *
+ * @example
+ * With monads:
+ * import { flow, map, flatMap, getOrElse, ok } from '@deessejs/core';
+ *
+ * const processUser = flow(
+ *   (id: string) => ok({ id, email: "user@test.com" }),
+ *   map(u => u.email),
+ *   getOrElse(() => 'unknown')
+ * );
+ *
+ * processUser("123"); // "user@test.com"
+ */
+export const flow = (...fns: Array<(arg: unknown) => unknown>) => (value: unknown): unknown =>
+  fns.reduce((acc, fn) => fn(acc), value);


### PR DESCRIPTION
## Summary

- Add `pipe()` for linear top-to-bottom value transformation
- Add `flow()` for creating reusable function pipelines (as requested in issue #160)
- Add `resultFromNullable()` for one-step nullable to Result conversion
- Add `resultFromThrowable()` as alternative to attempt() for naming consistency

Implements features from:
- Issue #159: pipe() function for linear composition
- Issue #160: flow() function for reusable pipelines
- Issue #158: direct shortcut functions

## Test plan

- [x] Type checking passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)