### PR TITLE
feat: add custom message template to Error system

### DIFF
--- a/packages/core/src/error.ts
+++ b/packages/core/src/error.ts
@@ -66,6 +66,7 @@ export type Error<T = unknown> = Readonly<{
   readonly notes: readonly string[];
   readonly cause: Error | null;
   readonly stack?: string;
+  readonly message?: string;
 }>;
 
 /**
@@ -84,6 +85,7 @@ export type ErrorOptions<T> = {
   readonly name: string;
   readonly args: T;
   readonly defaultDescription?: string;
+  readonly message?: (args: T) => string;
 };
 
 /**
@@ -94,6 +96,7 @@ export type ZodErrorOptions<T> = {
   readonly name: string;
   readonly schema: ZodSchema<T>;
   readonly defaultDescription?: string;
+  readonly message?: (args: T) => string;
 };
 
 /**
@@ -113,11 +116,6 @@ type ErrorBuilder<T> = {
   from(cause: Error | Err<Error>): ErrorBuilder<T>;
 };
 
-/**
- * Type guard to check if options has a Zod schema
- */
-const hasSchema = (options: ErrorOptions<unknown> | ZodErrorOptions<unknown>): options is ZodErrorOptions<unknown> =>
-  "schema" in options && options.schema instanceof ZodType;
 
 /**
  * Creates an Error type builder
@@ -144,9 +142,10 @@ const hasSchema = (options: ErrorOptions<unknown> | ZodErrorOptions<unknown>): o
  * const e = SizeError({ current: 3, wanted: 5 });
  */
 export const error = <T>(options: ErrorOptions<T> | ZodErrorOptions<T>): ErrorBuilder<T> => {
-  const isZod = hasSchema(options);
+  const isZod = "schema" in options && options.schema instanceof ZodType;
   const name = options.name;
-  const schema = isZod ? options.schema : null;
+  const schema = isZod ? (options as ZodErrorOptions<T>).schema : null;
+  const messageFn = "message" in options ? (options as ErrorOptions<T>).message : undefined;
 
   const createError = (args: T, notes: string[] = [], cause: Error | null = null): Error<T> => {
     // Capture stack trace
@@ -157,12 +156,16 @@ export const error = <T>(options: ErrorOptions<T> | ZodErrorOptions<T>): ErrorBu
       stack = err.stack.split('\n').slice(3).join('\n');
     }
 
+    // Generate custom message if provided
+    const customMessage = messageFn ? messageFn(args) : undefined;
+
     return Object.freeze({
       name,
       args,
       notes: Object.freeze([...notes]),
       cause,
       stack,
+      message: customMessage,
     });
   };
 
@@ -355,6 +358,10 @@ export const isErrTryWithError = (t: Try<unknown, unknown>): t is TryFailure<Err
 export const getErrorMessage = (e: Error | ErrorGroup): string => {
   if (isErrorGroup(e)) {
     return `${e.name}: ${e.exceptions.length} error(s)`;
+  }
+  // Use custom message if provided
+  if (e.message) {
+    return e.message;
   }
   return e.args
     ? `${e.name}: ${JSON.stringify(e.args)}`


### PR DESCRIPTION
## Summary

- Add optional `message` property to Error type
- Add `message` template function to ErrorOptions
- getErrorMessage() now uses custom message if provided, falls back to JSON args

Allows defining a custom message template when creating an error factory:

```typescript
const SizeError = error({
  name: "SizeError",
  args: {} as { current: number, wanted: number },
  message: (args) => \`Size must be at least \${args.wanted}, got \${args.current}\`
});
```

## Test plan

- [x] Type checking passes
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)