### PR TITLE
feat: add Documentation link to header

### DIFF
--- a/apps/web/src/lib/layout.shared.tsx
+++ b/apps/web/src/lib/layout.shared.tsx
@@ -6,5 +6,12 @@ export function baseOptions(): BaseLayoutProps {
       title: '@deessejs/fp',
     },
     githubUrl: 'https://github.com/nesalia-inc/fp',
+    links: [
+      {
+        text: 'Documentation',
+        url: '/docs',
+        active: 'nested-url',
+      },
+    ],
   };
 }


### PR DESCRIPTION
## Summary

Add "Documentation" link in the header navigation pointing to `/docs`.
Uses `nested-url` active state to highlight for all doc pages.

## Test plan

- [x] Lint passes
- [x] Typecheck passes

Co-Authored-By: martyy-code <nesalia.inc@gmail.com>