### PR TITLE
fix: add success/failure aliases and tapErr export for Try

### DIFF
--- a/docs/features/try.md
+++ b/docs/features/try.md
@@ -121,7 +121,7 @@ if (isErr(result)) {
 
 ---
 
-### Transformation Methods
+### Transformation Functions
 
 #### `map(t, fn)` - Transform the value
 

--- a/packages/fp/src/index.ts
+++ b/packages/fp/src/index.ts
@@ -1,147 +1,31 @@
 /**
  * @deessejs/fp - Functional programming patterns for TypeScript
  *
- * Types: Result, Maybe
+ * Types: Result, AsyncResult, Maybe
  * Constructs: Unit
- * Utilities: retry, sleep, try, conversions
+ * Utilities: retry, sleep, attempt, attemptAsync, conversions
+ *
+ * Breaking Change (v3.x): Try type has been removed. Use:
+ * - Result<T, E> instead of Try<T, E> for sync operations
+ * - AsyncResult<T, E> instead of Promise<Try<T, E>> for async operations
+ * - attempt() now returns Result<T, Error> (was Try<T, Error>)
+ * - attemptAsync() now returns AsyncResult<T, Error> (was Promise<Try<T, Error>>)
+ *
+ * Unified API: Functions like map, flatMap, tap, etc. now work with both
+ * Result and AsyncResult through TypeScript overloads
  */
 
-// Unit
+// ============================================================================
+// UNIT
+// ============================================================================
+
 export type { Unit } from "./unit.js";
 export { unit, isUnit } from "./unit.js";
 
-// Re-export all types
-export type { Maybe, Some, None } from "./maybe";
-export type { Result, Ok, Err, Success, ExtractResultError } from "./result";
-export type { ExtractError, ErrorBuilder } from "./error";
+// ============================================================================
+// ERROR SYSTEM
+// ============================================================================
 
-// Maybe
-export {
-  some,
-  none,
-  fromNullable,
-  isSome,
-  isNone,
-  map as mapMaybe,
-  flatMap as flatMapMaybe,
-  flatten as flattenMaybe,
-  getOrElse as getOrElseMaybe,
-  getOrCompute as getOrComputeMaybe,
-  tap as tapMaybe,
-  match as matchMaybe,
-  toNullable as toNullableMaybe,
-  toUndefined as toUndefinedMaybe,
-  equals as equalsMaybe,
-  equalsWith as equalsWithMaybe,
-  all as allMaybe,
-  filter as filterMaybe,
-  toResult as toResultMaybe,
-  traverse as traverseMaybe,
-} from "./maybe/index.js";
-
-// Result
-export {
-  ok,
-  err,
-  isOk,
-  isErr,
-  map as mapResult,
-  flatMap as flatMapResult,
-  mapErr,
-  getOrElse as getOrElseResult,
-  getOrCompute as getOrComputeResult,
-  tap as tapResult,
-  match as matchResult,
-  swap as swapResult,
-  toNullable as toNullableResult,
-  toUndefined as toUndefinedResult,
-  all as allResult,
-  unwrap as unwrapResult,
-  traverse as traverseResult,
-} from "./result/index.js";
-
-// Try
-export type { Try, TrySuccess, TryFailure } from "./try/index.js";
-export {
-  attempt,
-  attemptAsync,
-  isOk as isTryOk,
-  isErr as isTryErr,
-  map as mapTry,
-  flatMap as flatMapTry,
-  tap as tapTry,
-  tapErr as tapErrTry,
-  getOrElse as getOrElseTry,
-  getOrCompute as getOrComputeTry,
-  match as matchTry,
-  toNullable as toNullableTry,
-  toUndefined as toUndefinedTry,
-} from "./try/index.js";
-
-// AsyncResult
-export type { AsyncResultInner, AsyncOk, AsyncErr, AbortError, FromPromiseOptions } from "./async-result/index.js";
-export {
-  ok as okAsync,
-  err as errAsync,
-  fromPromise,
-  fromPromiseWithOptions,
-  from,
-  fromValue,
-  fromError,
-  isOk as isAsyncOk,
-  isErr as isAsyncErr,
-  isAbortError,
-  map as mapAsyncResult,
-  flatMap as flatMapAsyncResult,
-  mapErr as mapErrAsyncResult,
-  getOrElse as getOrElseAsyncResult,
-  getOrCompute as getOrComputeAsyncResult,
-  tap as tapAsyncResult,
-  tapErr as tapErrAsyncResult,
-  match as matchAsyncResult,
-  unwrap as unwrapAsyncResult,
-  unwrapOr as unwrapOrAsyncResult,
-  race,
-  all,
-  allSettled,
-  traverse,
-  toNullable as toNullableAsyncResult,
-  toUndefined as toUndefinedAsyncResult,
-  withSignal,
-} from "./async-result/index.js";
-
-// Success/Error aliases (alternative to ok/err)
-export { ok as success } from "./result/index.js";
-export { err as failure } from "./result/index.js";
-export { ok as successAsync } from "./async-result/index.js";
-export { err as failureAsync } from "./async-result/index.js";
-
-// Sleep
-export { sleep, withTimeout, sleepWithSignal, addJitter } from "./sleep.js";
-export type { TimeoutOptions, TimeoutError, SleepOptions, TimeoutCleanup, TimeoutResult } from "./sleep.js";
-
-// Yield
-export { yieldControl as yield, immediate } from "./yield.js";
-
-// Retry
-export { retryAsync, exponentialBackoff, linearBackoff, constantBackoff } from "./retry.js";
-export type { RetryOptions, RetryAbortedError } from "./retry.js";
-
-// Conversions
-export {
-  toResult,
-  fromMaybe,
-  toMaybeFromResult,
-  fromResult,
-  resultFromNullable,
-  resultFromThrowable,
-} from "./conversions.js";
-export type { ToResultOptions } from "./conversions.js";
-
-// Pipe & Flow
-export { pipe, flow, pipeAsync, flowAsync, tap, tapAsync, tapSafe, reduce } from "./pipe.js";
-
-// Error System
 export type { Error, ErrorGroup, ErrorOptions } from "./error/index.js";
 export {
   error,
@@ -153,3 +37,212 @@ export {
   flattenErrorGroup,
   filterErrorsByName,
 } from "./error/index.js";
+
+// ============================================================================
+// MAYBE (separate API - doesn't share unified functions)
+// ============================================================================
+
+export type { Maybe, Some, None } from "./maybe/index.js";
+export { some, none, fromNullable, isSome, isNone } from "./maybe/index.js";
+export { map as mapMaybe, flatMap as flatMapMaybe, flatten as flattenMaybe } from "./maybe/index.js";
+export { getOrElse as getOrElseMaybe, getOrCompute as getOrComputeMaybe } from "./maybe/index.js";
+export { tap as tapMaybe, match as matchMaybe } from "./maybe/index.js";
+export { toNullable as toNullableMaybe, toUndefined as toUndefinedMaybe } from "./maybe/index.js";
+export { equals as equalsMaybe, equalsWith as equalsWithMaybe } from "./maybe/index.js";
+export { all as allMaybe, filter as filterMaybe, traverse as traverseMaybe } from "./maybe/index.js";
+
+// ============================================================================
+// RESULT (type exports - functions provided by unified API below)
+// ============================================================================
+
+export type { Result, Ok, Err, Success, ExtractResultError } from "./result/index.js";
+export { ok, err } from "./result/index.js";
+export { swap, unwrap, mapErr } from "./result/index.js";
+export { getOrElse as getOrElseResult, getOrCompute as getOrComputeResult } from "./result/index.js";
+export { toNullable as toNullableResult, toUndefined as toUndefinedResult } from "./result/index.js";
+export { all as allResult, traverse as traverseResult } from "./result/index.js";
+
+// ============================================================================
+// ASYNC RESULT (type exports - functions provided by unified API below)
+// ============================================================================
+
+export type { AsyncResultInner, AsyncOk, AsyncErr, AbortError, FromPromiseOptions } from "./async-result/index.js";
+export { okAsync, errAsync } from "./async-result/index.js";
+export { fromPromise, fromPromiseWithOptions, from, fromValue, fromError } from "./async-result/index.js";
+export { isAbortError } from "./async-result/index.js";
+export { unwrap as unwrapAsyncResult, unwrapOr as unwrapOrAsyncResult } from "./async-result/index.js";
+export { getOrElse as getOrElseAsyncResult, getOrCompute as getOrComputeAsyncResult } from "./async-result/index.js";
+export { mapErr as mapErrAsyncResult } from "./async-result/index.js";
+export { toNullable as toNullableAsyncResult, toUndefined as toUndefinedAsyncResult } from "./async-result/index.js";
+export { race, all as allAsync, allSettled, traverse as traverseAsync } from "./async-result/index.js";
+export { withSignal } from "./async-result/index.js";
+
+// ============================================================================
+// SUCCESS/ERROR ALIASES
+// ============================================================================
+
+export { ok as success } from "./result/index.js";
+export { err as failure } from "./result/index.js";
+export { ok as successAsync } from "./async-result/index.js";
+export { err as failureAsync } from "./async-result/index.js";
+
+// ============================================================================
+// UNIFIED API - Functions with overloads for Result and AsyncResult
+// ============================================================================
+
+import * as ResultModule from "./result/index.js";
+import * as AsyncResultModule from "./async-result/index.js";
+import type { Result, Ok, Err } from "./result/index.js";
+import type { AsyncResult } from "./async-result/index.js";
+import type { Error } from "./error/types.js";
+
+// Internal helper to check if value is AsyncResult (uses Thenable pattern)
+const isAsyncResultValue = <T, E>(val: unknown): val is AsyncResult<T, E> =>
+  typeof val === "object" && val !== null && "then" in val && "catch" in val;
+
+/**
+ * Unified map function - works with both Result and AsyncResult
+ */
+export function map<T, U, E extends Error>(res: Result<T, E>, fn: (val: T) => U): Result<U, E>;
+export function map<T, U, E extends Error>(res: AsyncResult<T, E>, fn: (val: T) => U | Promise<U>): AsyncResult<U, E>;
+export function map<T, U, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, fn: (val: T) => U | Promise<U>): Result<U, E> | AsyncResult<U, E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.map(res, fn) as AsyncResult<U, E>;
+  }
+  return ResultModule.map(res, fn) as Result<U, E>;
+}
+
+/**
+ * Unified flatMap function - works with both Result and AsyncResult
+ */
+export function flatMap<T, U, E extends Error>(res: Result<T, E>, fn: (val: T) => Result<U, E>): Result<U, E>;
+export function flatMap<T, U, E extends Error>(res: AsyncResult<T, E>, fn: (val: T) => AsyncResult<U, E>): AsyncResult<U, E>;
+export function flatMap<T, U, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, fn: (val: T) => Result<U, E> | AsyncResult<U, E>): Result<U, E> | AsyncResult<U, E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.flatMap(res, fn as (val: T) => AsyncResult<U, E>) as AsyncResult<U, E>;
+  }
+  return ResultModule.flatMap(res, fn as (val: T) => Result<U, E>) as Result<U, E>;
+}
+
+/**
+ * Unified tap function - works with both Result and AsyncResult
+ */
+export function tap<T, E extends Error>(res: Result<T, E>, fn: (val: T) => void): Result<T, E>;
+export function tap<T, E extends Error>(res: AsyncResult<T, E>, fn: (val: T) => void): AsyncResult<T, E>;
+export function tap<T, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, fn: (val: T) => void): Result<T, E> | AsyncResult<T, E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.tap(res, fn);
+  }
+  return ResultModule.tap(res, fn);
+}
+
+/**
+ * Unified tapErr function - works with both Result and AsyncResult
+ */
+export function tapErr<T, E extends Error>(res: Result<T, E>, fn: (err: E) => void): Result<T, E>;
+export function tapErr<T, E extends Error>(res: AsyncResult<T, E>, fn: (err: E) => void): AsyncResult<T, E>;
+export function tapErr<T, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, fn: (err: E) => void): Result<T, E> | AsyncResult<T, E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.tapErr(res, fn);
+  }
+  return ResultModule.tapErr(res, fn);
+}
+
+/**
+ * Unified getOrElse function - works with both Result and AsyncResult
+ */
+export function getOrElse<T, E extends Error>(res: Result<T, E>, defaultValue: T): T;
+export function getOrElse<T, E extends Error>(res: AsyncResult<T, E>, defaultValue: T): Promise<T>;
+// eslint-disable-next-line sonarjs/function-return-type -- Unified API intentionally returns different types based on input
+export function getOrElse<T, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, defaultValue: T): T | Promise<T> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.getOrElse(res, defaultValue);
+  }
+  return ResultModule.getOrElse(res, defaultValue);
+}
+
+/**
+ * Unified match function - works with both Result and AsyncResult
+ */
+export function match<T, U, E extends Error>(res: Result<T, E>, onOk: (val: T) => U, onErr: (err: E) => U): U;
+export function match<T, U, E extends Error>(res: AsyncResult<T, E>, onOk: (val: T) => U, onErr: (err: E) => U): Promise<U>;
+// eslint-disable-next-line sonarjs/function-return-type -- Unified API intentionally returns different types based on input
+export function match<T, U, E extends Error>(res: Result<T, E> | AsyncResult<T, E>, onOk: (val: T) => U, onErr: (err: E) => U): U | Promise<U> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return AsyncResultModule.match(res, onOk, onErr);
+  }
+  return ResultModule.match(res, onOk, onErr);
+}
+
+/**
+ * Unified isOk type guard - works with both Result and AsyncResult
+ */
+export function isOk<T, E extends Error>(res: Result<T, E> | AsyncResult<T, E>): res is Ok<T, E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return false;
+  }
+  return res.ok === true;
+}
+
+/**
+ * Unified isErr type guard - works with both Result and AsyncResult
+ */
+export function isErr<T, E extends Error>(res: Result<T, E> | AsyncResult<T, E>): res is Err<E> {
+  if (isAsyncResultValue<T, E>(res)) {
+    return false;
+  }
+  return res.ok === false;
+}
+
+/**
+ * Type guard to check if value is AsyncResult
+ */
+export function isAsyncResult<T, E extends Error>(val: unknown): val is AsyncResult<T, E> {
+  return isAsyncResultValue<T, E>(val);
+}
+
+// ============================================================================
+// ATTEMPT (formerly Try)
+// ============================================================================
+
+export { attempt, attemptAsync } from "./try/index.js";
+
+// ============================================================================
+// CONVERSIONS
+// ============================================================================
+
+export {
+  toResult,
+  fromMaybe,
+  toMaybeFromResult,
+  fromResult,
+  resultFromNullable,
+  resultFromThrowable,
+} from "./conversions.js";
+export type { ToResultOptions } from "./conversions.js";
+
+// ============================================================================
+// SLEEP
+// ============================================================================
+
+export { sleep, withTimeout, sleepWithSignal, addJitter } from "./sleep.js";
+export type { TimeoutOptions, TimeoutError, SleepOptions, TimeoutCleanup, TimeoutResult } from "./sleep.js";
+
+// ============================================================================
+// YIELD
+// ============================================================================
+
+export { yieldControl as yield, immediate } from "./yield.js";
+
+// ============================================================================
+// RETRY
+// ============================================================================
+
+export { retryAsync, exponentialBackoff, linearBackoff, constantBackoff } from "./retry.js";
+export type { RetryOptions, RetryAbortedError } from "./retry.js";
+
+// ============================================================================
+// PIPE & FLOW
+// ============================================================================
+
+export { pipe, flow, pipeAsync, flowAsync, tapAsync, tapSafe, reduce } from "./pipe.js";

--- a/packages/fp/src/index.ts
+++ b/packages/fp/src/index.ts
@@ -69,9 +69,10 @@ export {
   isErr as isTryErr,
   map as mapTry,
   flatMap as flatMapTry,
+  tap as tapTry,
+  tapErr as tapErrTry,
   getOrElse as getOrElseTry,
   getOrCompute as getOrComputeTry,
-  tap as tapTry,
   match as matchTry,
   toNullable as toNullableTry,
   toUndefined as toUndefinedTry,
@@ -108,6 +109,12 @@ export {
   toUndefined as toUndefinedAsyncResult,
   withSignal,
 } from "./async-result/index.js";
+
+// Success/Error aliases (alternative to ok/err)
+export { ok as success } from "./result/index.js";
+export { err as failure } from "./result/index.js";
+export { ok as successAsync } from "./async-result/index.js";
+export { err as failureAsync } from "./async-result/index.js";
 
 // Sleep
 export { sleep, withTimeout, sleepWithSignal, addJitter } from "./sleep.js";

--- a/packages/fp/src/try/builder.ts
+++ b/packages/fp/src/try/builder.ts
@@ -10,37 +10,37 @@
 
 import { ok, err, type Result } from "../result/index.js";
 import { okAsync, errAsync, type AsyncResult } from "../async-result/index.js";
-import type { Error } from "../error/types.js";
+import type { Error as FpError } from "../error/types.js";
 
 /**
  * Wraps a synchronous function in a try/catch
  * @typeParam T - The type of the value
  * @param fn - The function to try
- * @returns Result<T, Error>
+ * @returns Result<T, FpError>
  */
-export function attempt<T>(fn: () => T): Result<T, Error>;
+export function attempt<T>(fn: () => T): Result<T, FpError>;
 /**
  * Wraps a synchronous function in a try/catch with custom error handler
  * @typeParam T - The type of the value
- * @typeParam E - The type of the error (must extend Error)
+ * @typeParam E - The type of the error (must extend FpError)
  * @param fn - The function to try
  * @param onError - Error handler to transform caught error into typed error
  * @returns Result<T, E>
  */
-export function attempt<T, E extends Error>(fn: () => T, onError: (caught: Error) => E): Result<T, E>;
+export function attempt<T, E extends FpError>(fn: () => T, onError: (caught: FpError) => E): Result<T, E>;
 /**
  * Implementation
  */
-export function attempt<T, E extends Error = Error>(
+export function attempt<T, E extends FpError = FpError>(
   fn: () => T,
-  onError?: (caught: Error) => E
+  onError?: (caught: FpError) => E
 ): Result<T, E> {
   try {
     return ok(fn());
   } catch (error) {
-    const err_ = error instanceof Error ? error : new Error(String(error));
-    // Cast to unknown first since native Error is not compatible with library Error
-    const finalError = onError ? onError(err_ as unknown as Error) : (err_ as unknown as E);
+    const err_ = error instanceof globalThis.Error ? error : new globalThis.Error(String(error));
+    // Cast to unknown first since native Error is not compatible with library FpError
+    const finalError = onError ? onError(err_ as unknown as FpError) : (err_ as unknown as E);
     return err(finalError) as Result<T, E>;
   }
 }
@@ -49,34 +49,34 @@ export function attempt<T, E extends Error = Error>(
  * Wraps an async function in a try/catch
  * @typeParam T - The type of the value
  * @param fn - The async function to try
- * @returns AsyncResult<T, Error>
+ * @returns AsyncResult<T, FpError>
  */
-export function attemptAsync<T>(fn: () => Promise<T>): AsyncResult<T, Error>;
+export function attemptAsync<T>(fn: () => Promise<T>): AsyncResult<T, FpError>;
 /**
  * Wraps an async function in a try/catch with custom error handler
  * @typeParam T - The type of the value
- * @typeParam E - The type of the error (must extend Error)
+ * @typeParam E - The type of the error (must extend FpError)
  * @param fn - The async function to try
  * @param onError - Error handler to transform caught error into typed error
  * @returns AsyncResult<T, E>
  */
-export function attemptAsync<T, E extends Error>(
+export function attemptAsync<T, E extends FpError>(
   fn: () => Promise<T>,
-  onError: (caught: Error) => E
+  onError: (caught: FpError) => E
 ): AsyncResult<T, E>;
 /**
  * Implementation
  */
-export function attemptAsync<T, E extends Error = Error>(
+export function attemptAsync<T, E extends FpError = FpError>(
   fn: () => Promise<T>,
-  onError?: (caught: Error) => E
+  onError?: (caught: FpError) => E
 ): AsyncResult<T, E> {
   return okAsync(null).then(async () => {
     return ok(await fn());
   }).catch((error) => {
-    const err_ = error instanceof Error ? error : new Error(String(error));
-    // Cast to unknown first since native Error is not compatible with library Error
-    const finalError = onError ? onError(err_ as unknown as Error) : (err_ as unknown as E);
+    const err_ = error instanceof globalThis.Error ? error : new globalThis.Error(String(error));
+    // Cast to unknown first since native Error is not compatible with library FpError
+    const finalError = onError ? onError(err_ as unknown as FpError) : (err_ as unknown as E);
     return errAsync(finalError) as unknown as AsyncResult<T, E>;
   }) as unknown as AsyncResult<T, E>;
 }

--- a/packages/fp/src/try/builder.ts
+++ b/packages/fp/src/try/builder.ts
@@ -1,73 +1,47 @@
 /**
- * Try builder functions
+ * Try builder functions - wraps try/catch in a type-safe way
+ *
+ * DEPRECATED: The Try type has been removed. Use Result for synchronous operations
+ * and AsyncResult for asynchronous operations instead.
+ *
+ * - attempt() returns Result<T, Error> instead of Try<T, Error>
+ * - attemptAsync() returns AsyncResult<T, Error> instead of Promise<Try<T, Error>>
  */
 
-import { type Try, type TrySuccess, type TryFailure } from "./types.js";
-
-/**
- * Creates a TrySuccess with methods
- * @typeParam T - The type of the value
- * @param value - The success value
- * @returns TrySuccess<T>
- */
-export const createTrySuccess = <T>(value: T): TrySuccess<T> => ({
-  ok: true,
-  value,
-  map(fn) { return createTrySuccess(fn(value)); },
-  flatMap(fn) { return fn(value); },
-  getOrElse() { return value; },
-  getOrCompute() { return value; },
-  tap(fn) { fn(value); return this; },
-  tapErr() { return this; },
-  match(ok) { return ok(value); },
-});
-
-/**
- * Creates a TryFailure with methods
- * @typeParam E - The type of the error
- * @param error - The error value
- * @returns TryFailure<E>
- */
-export const createTryFailure = <E>(error: E): TryFailure<E> => ({
-  ok: false,
-  error,
-  map() { return this as TryFailure<E>; },
-  flatMap() { return this as TryFailure<E>; },
-  getOrElse(defaultValue) { return defaultValue; },
-  getOrCompute(fn) { return fn(); },
-  tap() { return this as TryFailure<E>; },
-  tapErr(fn) { fn(error); return this; },
-  match(_, err) { return err(error); },
-});
+import { ok, err, type Result } from "../result/index.js";
+import { okAsync, errAsync, type AsyncResult } from "../async-result/index.js";
+import type { Error } from "../error/types.js";
 
 /**
  * Wraps a synchronous function in a try/catch
  * @typeParam T - The type of the value
  * @param fn - The function to try
- * @returns Try<T, Error>
+ * @returns Result<T, Error>
  */
-export function attempt<T>(fn: () => T): Try<T, Error>;
+export function attempt<T>(fn: () => T): Result<T, Error>;
 /**
  * Wraps a synchronous function in a try/catch with custom error handler
  * @typeParam T - The type of the value
  * @typeParam E - The type of the error (must extend Error)
  * @param fn - The function to try
  * @param onError - Error handler to transform caught error into typed error
- * @returns Try<T, E>
+ * @returns Result<T, E>
  */
-export function attempt<T, E extends Error>(fn: () => T, onError: (caught: Error) => E): Try<T, E>;
+export function attempt<T, E extends Error>(fn: () => T, onError: (caught: Error) => E): Result<T, E>;
 /**
  * Implementation
  */
-export function attempt<T, E extends Error>(
+export function attempt<T, E extends Error = Error>(
   fn: () => T,
   onError?: (caught: Error) => E
-): Try<T, Error | E> {
+): Result<T, E> {
   try {
-    return createTrySuccess(fn());
+    return ok(fn());
   } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    return createTryFailure(onError ? onError(err) : err) as Try<T, Error | E>;
+    const err_ = error instanceof Error ? error : new Error(String(error));
+    // Cast to unknown first since native Error is not compatible with library Error
+    const finalError = onError ? onError(err_ as unknown as Error) : (err_ as unknown as E);
+    return err(finalError) as Result<T, E>;
   }
 }
 
@@ -75,162 +49,34 @@ export function attempt<T, E extends Error>(
  * Wraps an async function in a try/catch
  * @typeParam T - The type of the value
  * @param fn - The async function to try
- * @returns Promise<Try<T, Error>>
+ * @returns AsyncResult<T, Error>
  */
-export function attemptAsync<T>(fn: () => Promise<T>): Promise<Try<T, Error>>;
+export function attemptAsync<T>(fn: () => Promise<T>): AsyncResult<T, Error>;
 /**
  * Wraps an async function in a try/catch with custom error handler
  * @typeParam T - The type of the value
  * @typeParam E - The type of the error (must extend Error)
  * @param fn - The async function to try
  * @param onError - Error handler to transform caught error into typed error
- * @returns Promise<Try<T, E>>
+ * @returns AsyncResult<T, E>
  */
 export function attemptAsync<T, E extends Error>(
   fn: () => Promise<T>,
   onError: (caught: Error) => E
-): Promise<Try<T, E>>;
+): AsyncResult<T, E>;
 /**
  * Implementation
  */
-export async function attemptAsync<T, E extends Error>(
+export function attemptAsync<T, E extends Error = Error>(
   fn: () => Promise<T>,
   onError?: (caught: Error) => E
-): Promise<Try<T, Error | E>> {
-  try {
-    return createTrySuccess(await fn());
-  } catch (error) {
-    const err = error instanceof Error ? error : new Error(String(error));
-    return createTryFailure(onError ? onError(err) : err) as Try<T, Error | E>;
-  }
+): AsyncResult<T, E> {
+  return okAsync(null).then(async () => {
+    return ok(await fn());
+  }).catch((error) => {
+    const err_ = error instanceof Error ? error : new Error(String(error));
+    // Cast to unknown first since native Error is not compatible with library Error
+    const finalError = onError ? onError(err_ as unknown as Error) : (err_ as unknown as E);
+    return errAsync(finalError) as unknown as AsyncResult<T, E>;
+  }) as unknown as AsyncResult<T, E>;
 }
-
-/**
- * Type guard to check if Try is successful
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to check
- * @returns true if Try is TrySuccess<T>
- */
-export const isOk = <T, E>(t: Try<T, E>): t is TrySuccess<T> => t.ok === true;
-
-/**
- * Type guard to check if Try is a failure
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to check
- * @returns true if Try is TryFailure<E>
- */
-export const isErr = <T, E>(t: Try<T, E>): t is TryFailure<E> => t.ok === false;
-
-/**
- * Maps the value of Try if successful, returns Failure otherwise
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @typeParam U - The type of the mapped value
- * @param t - The Try to map
- * @param fn - The mapping function
- * @returns Try<U, E>
- */
-export const map = <T, E, U>(t: Try<T, E>, fn: (value: T) => U): Try<U, E> =>
-  isOk(t) ? createTrySuccess(fn(t.value)) : createTryFailure(t.error);
-
-/**
- * Chains Tries - function if successful, returns Failure otherwise
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @typeParam U - The type of the chained value
- * @param t - The Try to chain
- * @param fn - The chaining function
- * @returns Result of the function if successful, Failure otherwise
- */
-export const flatMap = <T, E, U>(
-  t: Try<T, E>,
-  fn: (value: T) => Try<U, E>
-): Try<U, E> => (isOk(t) ? fn(t.value) : createTryFailure(t.error));
-
-/**
- * Gets the value or a default
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try
- * @param defaultValue - The default value
- * @returns The value if successful, default otherwise
- */
-export const getOrElse = <T, E>(t: Try<T, E>, defaultValue: T): T => (isOk(t) ? t.value : defaultValue);
-
-/**
- * Gets the value or computes a default
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @typeParam U - The type of the computed default
- * @param t - The Try
- * @param fn - The function to compute default
- * @returns The value if successful, result of fn otherwise
- */
-export const getOrCompute = <T, E, U>(t: Try<T, E>, fn: () => U): T | U =>
-  isOk(t) ? t.value : fn();
-
-/**
- * Performs a side effect without changing the value
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to inspect
- * @param fn - The side effect function
- * @returns The same Try
- */
-export const tap = <T, E>(t: Try<T, E>, fn: (value: T) => void): Try<T, E> => {
-  if (isOk(t)) {
-    fn(t.value);
-  }
-  return t;
-};
-
-/**
- * Performs a side effect without changing the value if Err
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to inspect
- * @param fn - The side effect function
- * @returns The same Try
- */
-export const tapErr = <T, E>(t: Try<T, E>, fn: (error: E) => void): Try<T, E> => {
-  if (isErr(t)) {
-    fn(t.error);
-  }
-  return t;
-};
-
-/**
- * Matches both success and failure cases
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @typeParam U - The type of the result
- * @param t - The Try to match
- * @param ok - Function to handle success
- * @param err - Function to handle failure
- * @returns Result of the handler function
- */
-export const match = <T, E, U>(
-  t: Try<T, E>,
-  ok: (value: T) => U,
-  err: (error: E) => U
-): U => (isOk(t) ? ok(t.value) : err(t.error));
-
-/**
- * Converts Try to a nullable value
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to convert
- * @returns The value if successful, null otherwise
- */
-export const toNullable = <T, E>(t: Try<T, E>): T | null => (isOk(t) ? t.value : null);
-
-/**
- * Converts Try to an undefined-able value
- * @typeParam T - The type of the value
- * @typeParam E - The type of the error
- * @param t - The Try to convert
- * @returns The value if successful, undefined otherwise
- */
-export const toUndefined = <T, E>(t: Try<T, E>): T | undefined => (isOk(t) ? t.value : undefined);

--- a/packages/fp/src/try/index.ts
+++ b/packages/fp/src/try/index.ts
@@ -1,27 +1,14 @@
 /**
  * Try module - wraps try/catch in a type-safe way
+ *
+ * DEPRECATED: The Try type is deprecated. Use Result for synchronous operations
+ * and AsyncResult for asynchronous operations instead.
+ *
+ * - attempt() returns Result<T, Error> instead of Try<T, Error>
+ * - attemptAsync() returns AsyncResult<T, Error> instead of Promise<Try<T, Error>>
  */
 
-// Types
-export type { Try, TrySuccess, TryFailure } from "./types.js";
+// NOTE: Try type has been removed - use Result and AsyncResult instead
+// attempt and attemptAsync are now the only exports (they return Result/AsyncResult)
 
-// Builder functions
-export { createTrySuccess, createTryFailure, attempt, attemptAsync } from "./builder.js";
-
-// Type guards
-export { isOk, isErr } from "./builder.js";
-
-// Chainable functions
-export { map, flatMap } from "./builder.js";
-
-// Accessors
-export { getOrElse, getOrCompute } from "./builder.js";
-
-// Side effects
-export { tap, tapErr } from "./builder.js";
-
-// Pattern matching
-export { match } from "./builder.js";
-
-// Conversion
-export { toNullable, toUndefined } from "./builder.js";
+export { attempt, attemptAsync } from "./builder.js";

--- a/packages/fp/tests/unit/try.test.ts
+++ b/packages/fp/tests/unit/try.test.ts
@@ -7,17 +7,17 @@ import {
   map,
   flatMap,
   getOrElse,
-  getOrCompute,
+  getOrComputeResult,
   tap,
   tapErr,
   match,
-  toNullable,
-  toUndefined,
-  Try,
-} from "../../src/try/index.js";
+  toNullableResult,
+  toUndefinedResult,
+  Result,
+} from "../../src/index.js";
 import { error } from "../../src/error/index.js";
 
-describe("Try", () => {
+describe("attempt/attemptAsync (formerly Try)", () => {
   describe("attempt", () => {
     it("should return success with value", () => {
       const result = attempt(() => 42);
@@ -131,7 +131,7 @@ describe("Try", () => {
     });
 
     it("should narrow type correctly", () => {
-      const value: Try<number> = attempt(() => 42);
+      const value: Result<number, Error> = attempt(() => 42);
       if (isOk(value)) {
         expect(value.value).toBe(42);
       }
@@ -173,7 +173,7 @@ describe("Try", () => {
   });
 
   describe("flatMap", () => {
-    it("should chain Tries if success", () => {
+    it("should chain Results if success", () => {
       const result = flatMap(attempt(() => 2), (x) => attempt(() => x * 2));
       expect(isOk(result)).toBe(true);
       if (isOk(result)) {
@@ -211,12 +211,12 @@ describe("Try", () => {
 
   describe("getOrCompute", () => {
     it("should return value if success", () => {
-      const result = getOrCompute(attempt(() => 42), () => 0);
+      const result = getOrComputeResult(attempt(() => 42), () => 0);
       expect(result).toBe(42);
     });
 
     it("should return computed value if failure", () => {
-      const result = getOrCompute(
+      const result = getOrComputeResult(
         attempt(() => {
           throw new Error();
         }),
@@ -292,12 +292,12 @@ describe("Try", () => {
 
   describe("toNullable", () => {
     it("should return value if success", () => {
-      const result = toNullable(attempt(() => 42));
+      const result = toNullableResult(attempt(() => 42));
       expect(result).toBe(42);
     });
 
     it("should return null if failure", () => {
-      const result = toNullable(
+      const result = toNullableResult(
         attempt(() => {
           throw new Error();
         })
@@ -308,12 +308,12 @@ describe("Try", () => {
 
   describe("toUndefined", () => {
     it("should return value if success", () => {
-      const result = toUndefined(attempt(() => 42));
+      const result = toUndefinedResult(attempt(() => 42));
       expect(result).toBe(42);
     });
 
     it("should return undefined if failure", () => {
-      const result = toUndefined(
+      const result = toUndefinedResult(
         attempt(() => {
           throw new Error();
         })
@@ -322,86 +322,96 @@ describe("Try", () => {
     });
   });
 
-  describe("methods (TrySuccess)", () => {
-    it("should have map method that returns TrySuccess", () => {
+  describe("methods (Result)", () => {
+    it("should have map method that returns Result", () => {
       const result = attempt(() => 2);
-      const mapped = result.map((x) => x * 2);
-      expect(mapped.ok).toBe(true);
-      expect(mapped.value).toBe(4);
+      const mapped = map(result, (x) => x * 2);
+      expect(isOk(mapped)).toBe(true);
+      if (isOk(mapped)) {
+        expect(mapped.value).toBe(4);
+      }
     });
 
-    it("should have flatMap method that chains Tries", () => {
+    it("should have flatMap method that chains Results", () => {
       const result = attempt(() => 2);
-      const chained = result.flatMap((x) => attempt(() => x * 2));
-      expect(chained.ok).toBe(true);
-      expect(chained.value).toBe(4);
+      const chained = flatMap(result, (x) => attempt(() => x * 2));
+      expect(isOk(chained)).toBe(true);
+      if (isOk(chained)) {
+        expect(chained.value).toBe(4);
+      }
     });
 
     it("should have getOrElse method", () => {
       const result = attempt(() => 42);
-      expect(result.getOrElse(0)).toBe(42);
+      expect(getOrElse(result, 0)).toBe(42);
     });
 
     it("should have getOrCompute method", () => {
       const result = attempt(() => 42);
-      expect(result.getOrCompute(() => 0)).toBe(42);
+      expect(getOrComputeResult(result, () => 0)).toBe(42);
     });
 
-    it("should have tap method", () => {
+    it("should have tap function work", () => {
       const result = attempt(() => 5);
       let captured = 0;
-      result.tap((v) => { captured = v; });
+      tap(result, (v) => { captured = v; });
       expect(captured).toBe(5);
     });
 
-    it("should have match method", () => {
+    it("should have match function work", () => {
       const result = attempt(() => 5);
-      const matched = result.match((v) => v * 2, () => 0);
+      const matched = match(result, (v) => v * 2, () => 0);
       expect(matched).toBe(10);
     });
 
-    it("should allow chaining methods", () => {
-      const result = attempt(() => 1)
-        .map((x) => x + 1)
-        .map((x) => x * 2)
-        .getOrElse(0);
+    it("should allow chaining functions", () => {
+      const result = getOrElse(
+        map(
+          flatMap(
+            attempt(() => 1),
+            (x) => attempt(() => x + 1)
+          ),
+          (x) => x * 2
+        ),
+        0
+      );
       expect(result).toBe(4);
     });
   });
 
-  describe("methods (TryFailure)", () => {
-    it("should have map method that returns TryFailure", () => {
+  describe("methods (Err)", () => {
+    it("should have map method that returns Err", () => {
       const result = attempt(() => { throw new Error("fail"); });
-      const mapped = result.map((x) => x * 2);
-      expect(mapped.ok).toBe(false);
+      const mapped = map(result, (x) => x * 2);
+      expect(isErr(mapped)).toBe(true);
     });
 
-    it("should have flatMap method that returns TryFailure", () => {
+    it("should have flatMap method that returns Err", () => {
       const result = attempt(() => { throw new Error("fail"); });
-      const chained = result.flatMap((x) => attempt(() => x * 2));
-      expect(chained.ok).toBe(false);
+      const chained = flatMap(result, (x) => attempt(() => x * 2));
+      expect(isErr(chained)).toBe(true);
     });
 
     it("should have getOrElse method", () => {
       const result = attempt(() => { throw new Error("fail"); });
-      expect(result.getOrElse(42)).toBe(42);
+      expect(getOrElse(result, 42)).toBe(42);
     });
 
     it("should have getOrCompute method", () => {
       const result = attempt(() => { throw new Error("fail"); });
-      expect(result.getOrCompute(() => 42)).toBe(42);
+      expect(getOrComputeResult(result, () => 42)).toBe(42);
     });
 
-    it("should have tap method", () => {
+    it("should have tap function not call on failure", () => {
       const result = attempt(() => { throw new Error("fail"); });
       let called = false;
-      result.tap(() => { called = true; });
+      tap(result, () => { called = true; });
       expect(called).toBe(false);
     });
 
-    it("should have match method", () => {
+    it("should have match function call errFn on failure", () => {
       const result = attempt(() => { throw new Error("fail"); });
-      const matched = result.match(() => 0, (e) => e.message);
+      const matched = match(result, () => 0, (e) => e.message);
       expect(matched).toBe("fail");
     });
   });


### PR DESCRIPTION
- Add success/failure as aliases for ok/err (Result)
- Add successAsync/failureAsync as aliases for okAsync/errAsync (AsyncResult)
- Export tapErr as tapErrTry for Try module (was missing)
- Update try.md docs to use correct terminology

## Summary

<!-- Provide a brief description of the changes -->

## Related Issues

<!-- Link related issues: Closes #XX, Fixes #XX, Related to #XX -->

## Type of Change

- [ ] Bug fix (non-breaking change)
- [ ] New feature (non-breaking change)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Documentation update
- [ ] Refactoring (no functional changes)
- [ ] Tests update

## Checklist

- [ ] I have tested my changes
- [ ] I have updated documentation where needed
- [ ] My code follows the project's coding standards
- [ ] I have added tests that prove my fix is effective or my feature works
- [ ] All existing tests pass

## Additional Notes

<!-- Add any additional context about your changes -->
