### PR TITLE
feat: initialize @deessejs/fp v1.0.0-alpha.1

### DIFF
--- a/.claude/agent-memory/tech-lead/MEMORY.md
+++ b/.claude/agent-memory/tech-lead/MEMORY.md
@@ -2,3 +2,4 @@
 - [Language Preference](language_preference.md) — Always communicate in English
 - [API Design Rule](api_design.md) — Public API uses functions, not classes. Internal classes OK.
 - [Project Structure](project_structure.md) — Folder structure per group: types.ts, constants.ts, builders.ts, index.ts
+- [No Inline Imports](no_inline_imports.md) — Never use inline `import()` in type definitions. Import types at top of file.

--- a/.claude/agent-memory/tech-lead/no_inline_imports.md
+++ b/.claude/agent-memory/tech-lead/no_inline_imports.md
@@ -1,0 +1,29 @@
+---
+name: No Inline Imports
+description: Inline import types are forbidden in type definitions
+type: feedback
+---
+
+# No Inline Imports
+
+**Rule:** Do not use inline `import` statements in type definitions.
+
+**Why:** Inline imports clutter the type definitions, make refactoring harder, and reduce readability.
+
+**How to apply:** Always import types at the top of the file. Never use `import('../module').Type` inline in interfaces.
+
+**Bad:**
+```typescript
+export interface Err {
+  toMaybe(): import('../maybe/types').Maybe<T>;  // FORBIDDEN
+}
+```
+
+**Good:**
+```typescript
+import type { Maybe } from '../maybe/types';
+
+export interface Err {
+  toMaybe(): Maybe<T>;
+}
+```

--- a/packages/fp/eslint.config.js
+++ b/packages/fp/eslint.config.js
@@ -7,10 +7,15 @@ export default tseslint.config(
   {
     files: ['src/**/*.ts'],
     rules: {
-      '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
+      '@typescript-eslint/no-unused-vars': ['error', {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+        caughtErrorsIgnorePattern: '^_',
+        destructuredArrayIgnorePattern: '^_',
+      }],
     },
   },
   {
-    ignores: ['dist/**', 'node_modules/**'],
+    ignores: ['dist/**', 'node_modules/**', 'examples/**'],
   }
 );

--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -2,6 +2,11 @@
   "name": "@deessejs/fp",
   "version": "1.0.0-alpha.1",
   "description": "Functional Programming Utilities for TypeScript",
+  "homepage": "https://fp.deessejs.com",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nesalia-inc/fp.git"
+  },
   "type": "module",
   "main": "./dist/index.js",
   "module": "./dist/index.js",

--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -28,10 +28,10 @@
   "author": "Nesalia Inc. <hello@nesalia.com>",
   "license": "MIT",
   "peerDependencies": {
-    "@deessejs/errors": "workspace:*"
+    "@deessejs/errors": ">=1.0.0"
   },
   "devDependencies": {
-    "@deessejs/errors": "workspace:*",
+    "@deessejs/errors": "^1.0.0",
     "@eslint/js": "^9.0.0",
     "eslint": "^9.0.0",
     "typescript": "^6.0.3",

--- a/packages/fp/src/index.test.ts
+++ b/packages/fp/src/index.test.ts
@@ -1,8 +1,118 @@
 import { describe, it, expect } from 'vitest';
-import { helloWorld } from '../src/index';
+import { ok, err, some, none, maybe, unit, isUnit } from '../src/index';
 
-describe('helloWorld', () => {
-  it('should return "Hello, World!"', () => {
-    expect(helloWorld()).toBe('Hello, World!');
+describe('Result', () => {
+  describe('ok', () => {
+    it('should create an Ok result', () => {
+      const result = ok(10);
+      expect(result.isOk()).toBe(true);
+      expect(result.isErr()).toBe(false);
+      expect(result.getOrNull()).toBe(10);
+    });
+
+    it('should map over Ok value', () => {
+      const result = ok(10).map((x) => x * 2);
+      expect(result.getOrNull()).toBe(20);
+    });
+
+    it('should match ok case', () => {
+      const result = ok(10).match({
+        ok: (v) => v * 2,
+        err: () => 0,
+      });
+      expect(result).toBe(20);
+    });
+  });
+
+  describe('err', () => {
+    it('should create an Err result', () => {
+      const result = err('error');
+      expect(result.isOk()).toBe(false);
+      expect(result.isErr()).toBe(true);
+      expect(result.getOrNull()).toBe(null);
+    });
+
+    it('should return null for getOrNull', () => {
+      const result = err('error');
+      expect(result.getOrNull()).toBe(null);
+    });
+
+    it('should match err case', () => {
+      const result = err('error').match({
+        ok: (v) => v,
+        err: (e) => `error: ${e}`,
+      });
+      expect(result).toBe('error: error');
+    });
+  });
+});
+
+describe('Maybe', () => {
+  describe('some', () => {
+    it('should create a Some', () => {
+      const result = some(10);
+      expect(result.isSome()).toBe(true);
+      expect(result.isNone()).toBe(false);
+      expect(result.getOrNull()).toBe(10);
+    });
+
+    it('should map over Some value', () => {
+      const result = some(10).map((x) => x * 2);
+      expect(result.getOrNull()).toBe(20);
+    });
+
+    it('should match some case', () => {
+      const result = some(10).match({
+        some: (v) => v * 2,
+        none: () => 0,
+      });
+      expect(result).toBe(20);
+    });
+  });
+
+  describe('none', () => {
+    it('should create a None', () => {
+      const result = none;
+      expect(result.isSome()).toBe(false);
+      expect(result.isNone()).toBe(true);
+    });
+
+    it('should return default value for getOrElse', () => {
+      expect(none.getOrElse(42)).toBe(42);
+    });
+
+    it('should match none case', () => {
+      const result = none.match({
+        some: (v) => v,
+        none: () => 0,
+      });
+      expect(result).toBe(0);
+    });
+  });
+
+  describe('maybe', () => {
+    it('should return Some for non-null value', () => {
+      const result = maybe(10);
+      expect(result.isSome()).toBe(true);
+    });
+
+    it('should return None for null', () => {
+      const result = maybe(null);
+      expect(result.isNone()).toBe(true);
+    });
+
+    it('should return None for undefined', () => {
+      const result = maybe(undefined);
+      expect(result.isNone()).toBe(true);
+    });
+  });
+});
+
+describe('Unit', () => {
+  it('should have correct structure', () => {
+    expect(isUnit(unit)).toBe(true);
+    expect(isUnit(null)).toBe(false);
+    expect(isUnit(undefined)).toBe(false);
+    expect(isUnit('not a unit')).toBe(false);
   });
 });

--- a/packages/fp/src/index.ts
+++ b/packages/fp/src/index.ts
@@ -5,13 +5,13 @@
  */
 
 // Result exports
-export type { Ok, Err, Result, ResultInstance } from './result/types';
+export type { Ok, Err, Result } from './result/types';
 export { ok, err } from './result/constants';
 // TODO: pipeable functions
 // export { map, flatMap, mapError, filter, tap, match, ... } from './result/functions';
 
 // Maybe exports
-export type { Some, None, Maybe, MaybeInstance } from './maybe/types';
+export type { Some, None, Maybe } from './maybe/types';
 export { some, none, maybe } from './maybe/constants';
 // TODO: pipeable functions
 // export { map, flatMap, filter, filterMap, tap, match, ... } from './maybe/functions';

--- a/packages/fp/src/maybe/constants.ts
+++ b/packages/fp/src/maybe/constants.ts
@@ -55,7 +55,7 @@ export function some<T>(value: T): Some<T> {
     get<K extends keyof T>(key: K): Maybe<T[K]> {
       return maybe(value[key]);
     },
-    toResult<E>(error: E): Result<T, E> {
+    toResult<E>(_error: E): Result<T, E> {
       return { _tag: 'Ok', value, isOk: () => true, isErr: () => false } as Result<T, E>;
     },
     toArray(): T[] {

--- a/packages/fp/src/maybe/index.ts
+++ b/packages/fp/src/maybe/index.ts
@@ -2,6 +2,6 @@
  * Maybe module exports
  */
 
-export type { Some, None, Maybe, MaybeInstance } from './types';
+export type { Some, None, Maybe } from './types';
 export { some, none, maybe } from './constants';
 // TODO: export instance methods as pipeable functions

--- a/packages/fp/src/maybe/types.ts
+++ b/packages/fp/src/maybe/types.ts
@@ -1,6 +1,4 @@
-/**
- * Maybe type interfaces: Some, None, Maybe
- */
+import type { Result } from '../result/types';
 
 /**
  * Some variant of Maybe - represents a present value
@@ -8,6 +6,26 @@
 export interface Some<T> {
   readonly _tag: 'Some';
   readonly value: T;
+
+  // Instance methods
+  map<B>(fn: (value: T) => B): Maybe<B>;
+  flatMap<B>(fn: (value: T) => Maybe<B>): Maybe<B>;
+  filter(predicate: (value: T) => boolean): Maybe<T>;
+  filterMap<B>(fn: (value: T) => Maybe<B>): Maybe<B>;
+  tap(fn: (value: T) => unknown): Maybe<T>;
+  tapAsync(fn: (value: T) => Promise<unknown>): Promise<Maybe<T>>;
+  match<U>(handlers: { some: (value: T) => U; none: () => U }): U;
+  fold<U>(onSome: (value: T) => U, _onNone: () => U): U;
+  getOrElse(_defaultValue: T): T;
+  getOrThrow(_message?: string): T;
+  getOrNull(): T | null;
+  getOrUndefined(): T | undefined;
+  get<K extends keyof T>(key: K): Maybe<T[K]>;
+  toResult<E>(_error: E): Result<T, E>;
+  toArray(): T[];
+  toIterable(): Iterable<T>;
+  isSome(): this is Some<T>;
+  isNone(): this is None;
 }
 
 /**
@@ -15,102 +33,29 @@ export interface Some<T> {
  */
 export interface None {
   readonly _tag: 'None';
+
+  // Instance methods
+  map<B>(_fn: (value: never) => B): Maybe<B>;
+  flatMap<B>(_fn: (value: never) => Maybe<B>): Maybe<B>;
+  filter(_predicate: (value: never) => boolean): Maybe<never>;
+  filterMap<B>(_fn: (value: never) => Maybe<B>): Maybe<B>;
+  tap(_fn: (value: never) => unknown): Maybe<never>;
+  tapAsync(_fn: (value: never) => Promise<unknown>): Promise<Maybe<never>>;
+  match<U>(handlers: { some: (value: never) => U; none: () => U }): U;
+  fold<U>(_onSome: (value: never) => U, onNone: () => U): U;
+  getOrElse<T>(defaultValue: T): T;
+  getOrThrow(message?: string): never;
+  getOrNull(): null;
+  getOrUndefined(): undefined;
+  get(_key: never): Maybe<never>;
+  toResult<E>(error: E): Result<never, E>;
+  toArray(): [];
+  toIterable(): Iterable<never>;
+  isSome(): this is Some<never>;
+  isNone(): this is None;
 }
 
 /**
  * Discriminated union of Some and None
  */
 export type Maybe<T> = Some<T> | None;
-
-// Instance methods
-export interface MaybeInstance<T> {
-  /**
-   * Transform the value if Some
-   */
-  map<B>(fn: (value: T) => B): Maybe<B>;
-
-  /**
-   * Chain Maybe computations
-   */
-  flatMap<B>(fn: (value: T) => Maybe<B>): Maybe<B>;
-
-  /**
-   * Filter based on predicate
-   */
-  filter(predicate: (value: T) => boolean): Maybe<T>;
-
-  /**
-   * Filter and map in one step
-   */
-  filterMap<B>(fn: (value: T) => Maybe<B>): Maybe<B>;
-
-  /**
-   * Execute side effect without transforming the value
-   */
-  tap(fn: (value: T) => unknown): Maybe<T>;
-
-  /**
-   * Execute async side effect
-   */
-  tapAsync(fn: (value: T) => Promise<unknown>): Promise<Maybe<T>>;
-
-  /**
-   * Pattern matching
-   */
-  match<U>(handlers: { some: (value: T) => U; none: () => U }): U;
-
-  /**
-   * Fold to a single value
-   */
-  fold<U>(onSome: (value: T) => U, onNone: () => U): U;
-
-  /**
-   * Get value or default
-   */
-  getOrElse(defaultValue: T): T;
-
-  /**
-   * Get value or throw
-   */
-  getOrThrow(message?: string): T;
-
-  /**
-   * Get value or null
-   */
-  getOrNull(): T | null;
-
-  /**
-   * Get value or undefined
-   */
-  getOrUndefined(): T | undefined;
-
-  /**
-   * Safe property access
-   */
-  get<K extends keyof T>(key: K): Maybe<T[K]>;
-
-  /**
-   * Convert to Result
-   */
-  toResult<E>(error: E): import('../result/types').Result<T, E>;
-
-  /**
-   * Convert to array
-   */
-  toArray(): T[];
-
-  /**
-   * Convert to iterable
-   */
-  toIterable(): Iterable<T>;
-
-  /**
-   * Type guard
-   */
-  isSome(): this is Some<T>;
-
-  /**
-   * Type guard
-   */
-  isNone(): this is None;
-}

--- a/packages/fp/src/result/index.ts
+++ b/packages/fp/src/result/index.ts
@@ -2,7 +2,7 @@
  * Result module exports
  */
 
-export type { Ok, Err, Result, ResultInstance } from './types';
+export type { Ok, Err, Result } from './types';
 export { ok, err } from './constants';
 // TODO: export instance methods as pipeable functions
 // export { map, flatMap, mapError, filter, tap, match, ... } from './functions';

--- a/packages/fp/src/result/types.ts
+++ b/packages/fp/src/result/types.ts
@@ -4,14 +4,50 @@
 export interface Ok<T, E = never> {
   readonly _tag: 'Ok';
   readonly value: T;
+
+  // Instance methods
+  map<B>(fn: (value: T) => B): Result<B, E>;
+  flatMap<B, E2>(fn: (value: T) => Result<B, E2>): Result<B, E | E2>;
+  mapError<E2>(_fn: (error: never) => E2): Result<T, E2>;
+  filter(predicate: (value: T) => boolean, _errorFn?: (value: T) => E): Result<T, E>;
+  tap(fn: (value: T) => unknown): Result<T, E>;
+  tapAsync(fn: (value: T) => Promise<unknown>): Promise<Result<T, E>>;
+  flatMapAsync<B, E2>(fn: (value: T) => Promise<Result<B, E2>>): Promise<Result<B, E | E2>>;
+  match<U>(handlers: { ok: (value: T) => U; err: (error: E) => U }): U;
+  fold<U>(onOk: (value: T) => U, _onErr: (error: E) => U): U;
+  getOrElse(_defaultValue: T): T;
+  getOrThrow(_message?: string): T;
+  getOrNull(): T | null;
+  getOrUndefined(): T | undefined;
+  toMaybe(): Maybe<T>;
+  isOk(): this is Ok<T, E>;
+  isErr(): this is Err<T, E>;
 }
 
 /**
  * Err variant of Result - represents a failed computation
  */
-export interface Err<T = never, E> {
+export interface Err<T = never, E = never> {
   readonly _tag: 'Err';
   readonly error: E;
+
+  // Instance methods
+  map<B>(_fn: (value: never) => B): Result<B, E>;
+  flatMap<B, E2>(_fn: (value: never) => Result<B, E2>): Result<B, E | E2>;
+  mapError<E2>(fn: (error: E) => E2): Result<T, E2>;
+  filter(_predicate: (value: never) => boolean, _errorFn?: (value: never) => E): Result<T, E>;
+  tap(_fn: (value: never) => unknown): Result<T, E>;
+  tapAsync(_fn: (value: never) => Promise<unknown>): Promise<Result<T, E>>;
+  flatMapAsync<B, E2>(_fn: (value: never) => Promise<Result<B, E2>>): Promise<Result<B, E | E2>>;
+  match<U>(handlers: { ok: (value: never) => U; err: (error: E) => U }): U;
+  fold<U>(_onOk: (value: never) => U, onErr: (error: E) => U): U;
+  getOrElse(defaultValue: T): T;
+  getOrThrow(message?: string): never;
+  getOrNull(): null;
+  getOrUndefined(): undefined;
+  toMaybe(): Maybe<T>;
+  isOk(): this is Ok<T, E>;
+  isErr(): this is Err<T, E>;
 }
 
 /**
@@ -19,85 +55,4 @@ export interface Err<T = never, E> {
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 
-// Instance methods
-export interface ResultInstance<T, E> {
-  /**
-   * Transform the Ok value
-   */
-  map<B>(fn: (value: T) => B): Result<B, E>;
-
-  /**
-   * Chain computations that may fail
-   */
-  flatMap<B, E2>(fn: (value: T) => Result<B, E2>): Result<B, E | E2>;
-
-  /**
-   * Transform the Err value (supports @deessejs/errors)
-   */
-  mapError<E2>(fn: (error: E) => E2): Result<T, E2>;
-
-  /**
-   * Filter Ok values based on a predicate
-   */
-  filter(predicate: (value: T) => boolean, errorFn?: (value: T) => E): Result<T, E>;
-
-  /**
-   * Execute side effect without transforming the value
-   */
-  tap(fn: (value: T) => unknown): Result<T, E>;
-
-  /**
-   * Execute async side effect without transforming the value
-   */
-  tapAsync(fn: (value: T) => Promise<unknown>): Promise<Result<T, E>>;
-
-  /**
-   * Async variant of flatMap
-   */
-  flatMapAsync<B, E2>(fn: (value: T) => Promise<Result<B, E2>>): Promise<Result<B, E | E2>>;
-
-  /**
-   * Pattern matching
-   */
-  match<U>(handlers: { ok: (value: T) => U; err: (error: E) => U }): U;
-
-  /**
-   * Fold to a single value
-   */
-  fold<U>(onOk: (value: T) => U, onErr: (error: E) => U): U;
-
-  /**
-   * Get value or default
-   */
-  getOrElse(defaultValue: T): T;
-
-  /**
-   * Get value or throw
-   */
-  getOrThrow(message?: string): T;
-
-  /**
-   * Get value or null
-   */
-  getOrNull(): T | null;
-
-  /**
-   * Get value or undefined
-   */
-  getOrUndefined(): T | undefined;
-
-  /**
-   * Convert to Maybe
-   */
-  toMaybe(): import('../maybe/types').Maybe<T>;
-
-  /**
-   * Type guard
-   */
-  isOk(): this is Ok<T, E>;
-
-  /**
-   * Type guard
-   */
-  isErr(): this is Err<T, E>;
-}
+import type { Maybe } from '../maybe/types';

--- a/packages/fp/src/types.ts
+++ b/packages/fp/src/types.ts
@@ -2,8 +2,8 @@
  * Shared type utilities for Result and Maybe
  */
 
-import type { Ok, Err, Result } from './result/types';
-import type { Some, None, Maybe } from './maybe/types';
+import type { Ok, Result } from './result/types';
+import type { Some, Maybe } from './maybe/types';
 
 /**
  * Check if a value is a Result

--- a/packages/fp/src/unit/types.ts
+++ b/packages/fp/src/unit/types.ts
@@ -2,7 +2,4 @@
  * Unit type - represents the absence of a meaningful return value.
  * Used for side-effect functions that don't return useful data.
  */
- * Unit type - represents the absence of a meaningful return value.
- * Used for side-effect functions that don't return useful data.
- */
 export type Unit = { readonly _tag: 'Unit' };

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -73,8 +73,11 @@ importers:
         specifier: ^6.0.3
         version: 6.0.3
 
-  packages/example:
+  packages/fp:
     devDependencies:
+      '@deessejs/errors':
+        specifier: ^1.0.0
+        version: 1.1.1
       '@eslint/js':
         specifier: ^9.0.0
         version: 9.39.4
@@ -222,6 +225,9 @@ packages:
 
   '@changesets/write@0.4.0':
     resolution: {integrity: sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q==}
+
+  '@deessejs/errors@1.1.1':
+    resolution: {integrity: sha512-iq9ei2OgoGqpuO37c7Mp4EBIFOZsyueGQLgavSwUKtExu0oSElWCzTcF568XUWRVAjrjlxWD8vcDyLRFPYSIZQ==}
 
   '@emnapi/core@1.10.0':
     resolution: {integrity: sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==}
@@ -4115,6 +4121,10 @@ snapshots:
       fs-extra: 7.0.1
       human-id: 4.1.3
       prettier: 2.8.8
+
+  '@deessejs/errors@1.1.1':
+    dependencies:
+      '@standard-schema/spec': 1.1.0
 
   '@emnapi/core@1.10.0':
     dependencies:


### PR DESCRIPTION
## Summary

Initialize `@deessejs/fp` package foundation with core types for v1.0.0-alpha.1.

### Core Types Added

- **Result<T, E>** — Ok/Err discriminated union with instance methods
  - `ok()`, `err()` constructors
  - `map`, `flatMap`, `filter`, `tap`, `match`, `fold`, `getOrElse`, `mapError`
  - `isOk()`, `isErr()` type guards
  - `@deessejs/errors` integration via `mapError`

- **Maybe<T>** — Some/None discriminated union
  - `some()`, `none()`, `maybe()` constructors
  - `map`, `flatMap`, `filter`, `getOrElse`
  - Safe property access with `get<K>()`
  - `isSome()`, `isNone()` type guards

- **Unit** — Singleton type for side-effect functions
  - `unit` constant
  - `isUnit()` type guard

### Package Structure

```
packages/fp/
├── src/
│   ├── result/   # Ok, Err, Result
│   ├── maybe/    # Some, None, Maybe
│   ├── unit/     # Unit
│   └── index.ts  # barrel exports
├── examples/
│   ├── json-parse.ts
│   ├── safe-access.ts
│   ├── user-profile.ts
│   └── dual-api.ts
└── package.json
```

### Documentation

- Feature docs for Result, Maybe, Unit, Try, Async, etc.
- Version specs: v1.0.0-alpha.1 through v1.1.0

## Test plan

- [x] All 4 examples run successfully
- [ ] Add unit tests
- [ ] Add type tests

🤖 Generated with [Claude Code](https://claude.ai/code)