### PR TITLE
fix: pull --rebase before push in release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,7 @@ jobs:
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
+          git pull --rebase origin main
           git add -A
           git commit -m "chore: apply changeset version bumps" || true
           git push origin HEAD && git push --tags


### PR DESCRIPTION
## Summary

- Add `git pull --rebase origin main` before pushing version bumps
- Fixes push rejection when remote has new commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)