### PR TITLE
chore(fp): version bump — emit .js extensions in published ESM imports (#356)

### DIFF
--- a/.changeset/fix-esm-import-extensions.md
+++ b/.changeset/fix-esm-import-extensions.md
@@ -1,0 +1,7 @@
+---
+'@deessejs/fp': patch
+---
+
+Fix: emit explicit `.js` extensions on relative imports in the published `dist/` so Node ESM consumers (strict mode) can resolve them. This unblocks Vitest and other test runners that don't bundle on import.
+
+Switches `packages/fp/tsconfig.json` to `module: NodeNext` + `moduleResolution: NodeNext` and updates source-level relative imports to include the `.js` suffix, as recommended by the TypeScript team for dual ESM/CJS packages.

--- a/packages/fp/src/index.test.ts
+++ b/packages/fp/src/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { ok, err, some, none, maybe, unit, isUnit } from '../src/index';
+import { ok, err, some, none, maybe, unit, isUnit } from '../src/index.js';
 
 describe('Result', () => {
   describe('ok', () => {

--- a/packages/fp/src/index.ts
+++ b/packages/fp/src/index.ts
@@ -5,41 +5,41 @@
  */
 
 // Result exports
-export type { Ok, Err, Result } from './result/types';
-export { ok, err } from './result/constants';
+export type { Ok, Err, Result } from './result/types.js';
+export { ok, err } from './result/constants.js';
 // TODO: pipeable functions
-// export { map, flatMap, mapError, filter, tap, match, ... } from './result/functions';
+// export { map, flatMap, mapError, filter, tap, match, ... } from './result/functions.js';
 
 // Maybe exports
-export type { Some, None, Maybe } from './maybe/types';
-export { some, none, maybe } from './maybe/constants';
+export type { Some, None, Maybe } from './maybe/types.js';
+export { some, none, maybe } from './maybe/constants.js';
 // TODO: pipeable functions
-// export { map, flatMap, filter, filterMap, tap, match, ... } from './maybe/functions';
+// export { map, flatMap, filter, filterMap, tap, match, ... } from './maybe/functions.js';
 
 // Unit exports
-export type { Unit } from './unit/types';
-export { unit, isUnit } from './unit/constants';
+export type { Unit } from './unit/types.js';
+export { unit, isUnit } from './unit/constants.js';
 
 // Type utilities
-export { isResult, isMaybe } from './types';
-export type { OkType, ErrType, SomeType } from './types';
+export { isResult, isMaybe } from './types.js';
+export type { OkType, ErrType, SomeType } from './types.js';
 
 // TODO: pipe utility
-// export { pipe } from './pipe';
+// export { pipe } from './pipe.js';
 
 // TODO: Async utilities
-// export { try_, tryPromise } from './try';
-// export { sleep, retry, timeout, queue, jitter } from './async';
-// export { collect, first, last, mapAsync, filterAsync } from './async-iterator';
+// export { try_, tryPromise } from './try.js';
+// export { sleep, retry, timeout, queue, jitter } from './async.js';
+// export { collect, first, last, mapAsync, filterAsync } from './async-iterator.js';
 
 // TODO: Collection types
-// export { Context, Sequence, Collection } from './collection';
+// export { Context, Sequence, Collection } from './collection.js';
 
 // TODO: Generator composition
-// export { gen } from './generator';
+// export { gen } from './generator.js';
 
 // TODO: Serialization
-// export { serialize, deserialize, partition } from './serialization';
+// export { serialize, deserialize, partition } from './serialization.js';
 
 // TODO: Predicates
-// export { Predicate, Refinement, not, and, or } from './predicate';
+// export { Predicate, Refinement, not, and, or } from './predicate.js';

--- a/packages/fp/src/maybe/constants.ts
+++ b/packages/fp/src/maybe/constants.ts
@@ -2,8 +2,8 @@
  * Maybe constructors: some(), none(), maybe()
  */
 
-import type { Some, None, Maybe } from './types';
-import type { Result } from '../result/types';
+import type { Some, None, Maybe } from './types.js';
+import type { Result } from '../result/types.js';
 
 /**
  * Create a Some Maybe

--- a/packages/fp/src/maybe/index.ts
+++ b/packages/fp/src/maybe/index.ts
@@ -2,6 +2,6 @@
  * Maybe module exports
  */
 
-export type { Some, None, Maybe } from './types';
-export { some, none, maybe } from './constants';
+export type { Some, None, Maybe } from './types.js';
+export { some, none, maybe } from './constants.js';
 // TODO: export instance methods as pipeable functions

--- a/packages/fp/src/maybe/types.ts
+++ b/packages/fp/src/maybe/types.ts
@@ -1,4 +1,4 @@
-import type { Result } from '../result/types';
+import type { Result } from '../result/types.js';
 
 /**
  * Some variant of Maybe - represents a present value

--- a/packages/fp/src/result/constants.ts
+++ b/packages/fp/src/result/constants.ts
@@ -2,8 +2,8 @@
  * Result constructors: ok(), err()
  */
 
-import type { Ok, Err, Result } from './types';
-import type { Maybe } from '../maybe/types';
+import type { Ok, Err, Result } from './types.js';
+import type { Maybe } from '../maybe/types.js';
 
 /**
  * Create an Ok result

--- a/packages/fp/src/result/index.ts
+++ b/packages/fp/src/result/index.ts
@@ -2,7 +2,7 @@
  * Result module exports
  */
 
-export type { Ok, Err, Result } from './types';
-export { ok, err } from './constants';
+export type { Ok, Err, Result } from './types.js';
+export { ok, err } from './constants.js';
 // TODO: export instance methods as pipeable functions
-// export { map, flatMap, mapError, filter, tap, match, ... } from './functions';
+// export { map, flatMap, mapError, filter, tap, match, ... } from './functions.js';

--- a/packages/fp/src/result/types.ts
+++ b/packages/fp/src/result/types.ts
@@ -57,4 +57,4 @@ export interface Err<T = never, E = never> {
  */
 export type Result<T, E> = Ok<T, E> | Err<T, E>;
 
-import type { Maybe } from '../maybe/types';
+import type { Maybe } from '../maybe/types.js';

--- a/packages/fp/src/types.ts
+++ b/packages/fp/src/types.ts
@@ -2,8 +2,8 @@
  * Shared type utilities for Result and Maybe
  */
 
-import type { Ok, Result } from './result/types';
-import type { Some, Maybe } from './maybe/types';
+import type { Ok, Result } from './result/types.js';
+import type { Some, Maybe } from './maybe/types.js';
 
 /**
  * Check if a value is a Result

--- a/packages/fp/src/unit/constants.ts
+++ b/packages/fp/src/unit/constants.ts
@@ -2,7 +2,7 @@
  * Unit constants and utilities
  */
 
-import type { Unit } from './types';
+import type { Unit } from './types.js';
 
 /**
  * The Unit singleton value

--- a/packages/fp/src/unit/index.ts
+++ b/packages/fp/src/unit/index.ts
@@ -2,5 +2,5 @@
  * Unit module exports
  */
 
-export type { Unit } from './types';
-export { unit, isUnit } from './constants';
+export type { Unit } from './types.js';
+export { unit, isUnit } from './constants.js';

--- a/packages/fp/tsconfig.json
+++ b/packages/fp/tsconfig.json
@@ -1,8 +1,8 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "ESNext",
-    "moduleResolution": "bundler",
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
     "declaration": true,
     "declarationMap": true,
     "outDir": "./dist",


### PR DESCRIPTION
## Summary

Fixes #356 — the published `dist/index.js` used extensionless relative imports (e.g. `./result/constants`), which bundlers resolve transparently but Node ESM strict mode rejects. This broke consumers running Vitest or any other test runner that does not bundle on import.

## Changes

- `packages/fp/tsconfig.json`: switch `module` and `moduleResolution` from `ESNext`/`bundler` to `NodeNext` so `tsc` emits `.js` extensions on relative imports in the compiled output.
- `packages/fp/src/**`: add an explicit `.js` suffix to every relative import (including the test file and the commented-out TODO exports, so they stay consistent if uncommented later).
- `.changeset/fix-esm-import-extensions.md`: patch-level changeset entry.

## Why NodeNext

This is the modern TypeScript recommendation for dual ESM/CJS packages. It produces output that Node ESM resolves without flags, while remaining transparent to bundlers (esbuild, Vite, tsup) that already handle `.js` suffixes in source imports.

## Verification

Performed locally on Windows with pnpm 10:

- `pnpm --filter @deessejs/fp type-check` — passes.
- `pnpm --filter @deessejs/fp build` — `dist/` regenerated; every relative import now carries a `.js` suffix.
- `pnpm --filter @deessejs/fp test:run` — 16/16 tests pass.
- `pnpm --filter @deessejs/fp lint` — passes.
- Reproduced the reporter's scenario: a standalone `type: module` package linking `@deessejs/fp` from the freshly built `dist/` and importing `ok`, `err`, `some`, `none`, `maybe`, `unit`, `isUnit` via `node smoke.mjs` runs successfully (no `ERR_MODULE_NOT_FOUND`).

## Notes for reviewers

- The `dist/` directory is gitignored and will be regenerated by the `release.yml` workflow on the next version bump, so this PR contains source changes only.
- No runtime/API changes — purely a build-configuration and source-import fix.
- Follow-up work tracked separately: `isResult`/`isMaybe` narrowing bug, missing tests for async methods, and the long list of `// TODO` exports (pipe, async utilities, etc.) noted in the original issue analysis.