### PR TITLE
fix(ci): make release.yml robust to non-empty working trees

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,10 +18,12 @@ jobs:
     if: github.event_name == 'workflow_dispatch' || (github.event.pull_request.merged == true && contains(github.event.pull_request.labels.*.name, 'version bump'))
 
     steps:
-      - name: Checkout
+      - name: Checkout main
         uses: actions/checkout@v4
         with:
+          ref: main
           fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup pnpm
         uses: pnpm/action-setup@v4
@@ -33,39 +35,53 @@ jobs:
           cache: 'pnpm'
 
       - name: Install dependencies
-        run: pnpm install
+        run: pnpm install --frozen-lockfile
 
       - name: Create versions from changesets
-        run: pnpm changeset version
-
-      - name: Commit version changes and push
+        id: version
         run: |
-          git config user.name "github-actions[bot]"
-          git config user.email "github-actions[bot]@users.noreply.github.com"
-          git pull --rebase origin main
-          git add -A
-          git commit -m "chore: apply changeset version bumps" || true
-          git push origin HEAD && git push --tags
+          pnpm changeset version
+          if git diff --quiet; then
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+            echo "No changesets to apply, skipping release."
+          else
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          fi
 
       - name: Build
+        if: steps.version.outputs.changed == 'true'
         run: pnpm build
 
       - name: Test
+        if: steps.version.outputs.changed == 'true'
         run: pnpm test
 
+      - name: Commit version changes and push
+        if: steps.version.outputs.changed == 'true'
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add -A
+          git commit -m "chore: apply changeset version bumps"
+          git push origin main
+
       - name: Configure npm
+        if: steps.version.outputs.changed == 'true'
         run: npm config set //registry.npmjs.org/:_authToken=$NPM_TOKEN
         env:
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Publish packages
+        if: steps.version.outputs.changed == 'true' && secrets.NPM_TOKEN != ''
         run: pnpm changeset publish
 
       - name: Get latest tag
         id: tag
+        if: steps.version.outputs.changed == 'true'
         run: echo "version=$(git describe --tags --abbrev=0)" >> $GITHUB_OUTPUT
 
       - name: Create GitHub Release
+        if: steps.version.outputs.changed == 'true'
         uses: softprops/action-gh-release@v2
         with:
           tag_name: ${{ steps.tag.outputs.version }}


### PR DESCRIPTION
## Summary

The `release.yml` workflow runs on every `pull_request` event whose labels include `version bump` — not just on `pull_request: closed`. When the previous fix PR (#357) was merged, it triggered the workflow on its own closure and immediately failed at:

```
error: cannot pull with rebase: You have unstaged changes.
Process completed with exit code 128.
```

Two root causes:

1. The step checked out the PR's source branch (not `main`), then tried to `git pull --rebase origin main` while `pnpm changeset version` had just modified files in the working tree — so the rebase refused to start.
2. The release ran even when there was nothing to release, on every labeled PR, with no guard against a missing `NPM_TOKEN`.

## Changes

Checkout `main` explicitly with a token that can push, and gate the rest of the job on whether `pnpm changeset version` actually produced a diff:

- `actions/checkout` now uses `ref: main` + `token: ${{ secrets.GITHUB_TOKEN }}`.
- New step `Create versions from changesets` captures `changed=true|false` based on `git diff --quiet`.
- Build, test, commit, publish, GitHub Release all run only if `changed=true`.
- Build and test now run **before** the version commit so a broken build no longer leaves a version bump commit on `main`.
- `git add -A` before the version commit; the trailing `|| true` is removed so failures are loud.
- Push targets `origin main` explicitly instead of `HEAD` (which was the merged PR branch).
- Publish step also requires `secrets.NPM_TOKEN != ''`.
- `pnpm install --frozen-lockfile` to detect lockfile drift early.

## How to trigger the actual release

The patch changeset from #356 (`.changeset/fix-esm-import-extensions.md`) is already on `main`. Once this PR is merged, the workflow will not auto-trigger (no `pull_request: closed` event for it because no version-bump label). The release has to be launched by:

1. Merging this PR.
2. Triggering the workflow manually via the Actions tab → Release → Run workflow, **or** opening and merging a trivial `chore: trigger release` PR labelled `version bump`.

## Verification

- Local: `pnpm turbo type-check` passes for both packages.
- The workflow itself cannot be dry-run from this environment; manual verification required after merge.