### PR TITLE
ci(changesets): fix input name for v1 action (commit-message -> commit)

### DIFF
--- a/.github/workflows/changeset-version.yml
+++ b/.github/workflows/changeset-version.yml
@@ -49,7 +49,7 @@ jobs:
         uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d
         with:
           title: 'chore: version packages'
-          commit-message: 'chore: version packages'
+          commit: 'chore: version packages'
           branch: changesets/version
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Fixes the `changesets/action` input name in `changeset-version.yml`: `commit-message` → `commit`. The former is a v2 input; we're using v1.9.0.

## Why

The Changesets Version PR workflow failed on the e2e test (PR #370 merge to staging) with:

```
Unexpected input(s) 'commit-message', valid inputs are
['github-token', 'publish', 'version', 'cwd', 'commit',
 'title', 'setupGitUser', 'createGithubReleases', 'commitMode',
 'branch', 'prDraft']
```

The action version is pinned at `a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d` (v1.9.0). v1 uses `commit`, v2 uses `commit-message`. Mixed up by the original PR.

## Changes

`.github/workflows/changeset-version.yml`: rename the input `commit-message` to `commit`.

## Required follow-up

The workflow also requires the org/repo setting "Allow GitHub Actions to create and approve pull requests" (Settings → Actions → General). This is in `docs/engineering/plans/release-pipeline-github-ui-setup.md` §6 but was not yet enabled in the UI. Once both fixes are in place, the next push to staging will open the Version Packages PR.

## Test plan

- [x] `pnpm turbo type-check` passes.
- [x] `pnpm turbo lint` passes.
- [ ] After UI setting is enabled + this PR merged: next push to staging opens a "chore: version packages" PR targeting main.

## Risk

**None.** One-word change to a workflow input.

🤖 Generated with [Claude Code](https://claude.com/claude-code)