### PR TITLE
ci(publish): ungate release and hotfix from check-release

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -73,11 +73,17 @@ jobs:
 
   # Stable release: triggered by push to main after a "Version
   # Packages" PR is merged.
+  #
+  # Note: this job is NOT gated on check-release. The reason is
+  # that by the time the push reaches main, the changeset has
+  # already been consumed by the Version Packages PR. The
+  # .changeset/ directory is empty. The actual gate for whether
+  # to publish is the anti-republish guard: if the local version
+  # already exists on npm, the publish step fails cleanly and
+  # the job exits without publishing.
   release:
-    needs: check-release
     if: >-
-      needs.check-release.outputs.has_changeset == 'true'
-      && github.event_name == 'push'
+      github.event_name == 'push'
       && !startsWith(github.ref, 'refs/tags/')
     runs-on: ubuntu-latest
     environment: release
@@ -147,8 +153,12 @@ jobs:
 
   # Hotfix: triggered by a tag push on main. The tag is created by
   # a maintainer as part of the hotfix procedure.
+  #
+  # Note: not gated on check-release. Tag pushes always publish;
+  # the package.json version must match the tag (verified by the
+  # 'Verify version matches tag' step), and the anti-republish
+  # guard catches duplicate publishes.
   hotfix:
-    needs: check-release
     if: >-
       github.event_name == 'push'
       && startsWith(github.ref, 'refs/tags/v')


### PR DESCRIPTION
## Summary

Removes the `check-release` dependency from the `release` and `hotfix` jobs in `publish.yml`. Both jobs now run on their respective triggers (push to main, tag push to main) and rely on the anti-republish guard as their sole publish gate.

## Why

The `check-release` job counts `.changeset/*.md` files to decide whether to publish. This was intended to skip publish workflows on infra-only pushes to main (e.g. CI changes, doc edits) where there is nothing to release.

Problem observed on the e2e test (PR #375 merge to main): when a Version Packages PR is merged into main, the changeset has already been consumed. `.changeset/` is empty. `check-release` reports "no pending changesets" and gates the release job off — even though there is a real release to publish.

This means the canonical release path (Version Packages PR → main merge → publish) is broken: the publish job never runs.

## Senior rationale

The `release` and `hotfix` jobs have their own intrinsic gates:

- **release** has the anti-republish guard: queries npm for the local version. If it exists, exit cleanly with an explicit error. If not, proceed with publish.
- **hotfix** has the "Verify version matches tag" step: confirms that `package.json#version` equals the tag, then runs the same anti-republish guard.

These are stronger guarantees than the `check-release` heuristic (which is just "is there an unconsumed changeset in `.changeset/`"). Pushing the gating out of the entrypoint and into the job makes the pipeline robust to timing issues between Changesets consumption and main arrival.

The `check-release` job is kept and gates the `canary` job only — because canary snapshotting a non-existent changeset is meaningless. For release/hotfix, the trigger itself (push to main, tag push) is the signal of intent.

## Changes

`publish.yml`:

- `release` job: remove `needs: check-release`. Remove the `has_changeset` clause from `if`. Add a comment explaining the design.
- `hotfix` job: same. Add a comment.
- `canary` job: unchanged. Still gated on `check-release`.
- `check-release` job: unchanged.

## Test plan

- [x] `pnpm turbo type-check` passes.
- [x] `pnpm turbo lint` passes.
- [ ] Post-merge: re-run the e2e test scenario by pushing the existing `changeset-release/changesets/version` branch or any branch with a version bump to main → release job runs and publishes with provenance.

## Risk

**Low.** The anti-republish guard is preserved and unchanged. The only behavioral change is that the release job now runs on every push to main (where before it was skipped when no changeset was present). Pushes that don't bump the version will fail the anti-republish guard cleanly with no publish.

## Rollback

Revert the merge commit. The previous (broken) gating behavior returns.

🤖 Generated with [Claude Code](https://claude.com/claude-code)