### PR TITLE
ci(publish): fix smoke test for object sentinel exports

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -127,9 +127,13 @@ jobs:
         run: |
           node --input-type=module -e "
             import * as m from './packages/fp/dist/index.js';
+            // Each expected export must exist and be either a
+            // function (constructors ok/err/some/maybe) or an
+            // object sentinel (none is a const object).
             for (const name of ['ok', 'err', 'some', 'none', 'maybe']) {
-              if (typeof m[name] !== 'function') {
-                throw new Error('expected export missing: ' + name);
+              const t = typeof m[name];
+              if (t !== 'function' && t !== 'object') {
+                throw new Error('expected export missing or wrong type: ' + name + ' (got ' + t + ')');
               }
             }
             console.log('smoke OK');
@@ -216,9 +220,13 @@ jobs:
         run: |
           node --input-type=module -e "
             import * as m from './packages/fp/dist/index.js';
+            // Each expected export must exist and be either a
+            // function (constructors ok/err/some/maybe) or an
+            // object sentinel (none is a const object).
             for (const name of ['ok', 'err', 'some', 'none', 'maybe']) {
-              if (typeof m[name] !== 'function') {
-                throw new Error('expected export missing: ' + name);
+              const t = typeof m[name];
+              if (t !== 'function' && t !== 'object') {
+                throw new Error('expected export missing or wrong type: ' + name + ' (got ' + t + ')');
               }
             }
             console.log('smoke OK');


### PR DESCRIPTION
## Summary

Fixes the smoke test step in `publish.yml` so it accepts both functions and object sentinels when checking exports. The `none` export is `export const none: None = { ... }` (an object), but the smoke test was asserting `typeof === 'function'`, which rejected it.

## Why

After #376 was merged and the e2e test was re-triggered, the release job progressed past the anti-republish guard but failed at the smoke test:

```
Error: expected export missing: none
```

`none` is correctly exported, but it's an `object`, not a `function`. The smoke test incorrectly assumed every expected export was a function constructor.

## Changes

`.github/workflows/publish.yml`: both smoke test occurrences (release and hotfix) now accept either `function` or `object` types. Sentinel constants like `none` are now validated.

The first commit on this branch (#376, already merged) removed the `check-release` gate from the release job. This commit adds the smoke test fix on top.

## Test plan

- [x] `pnpm turbo type-check` passes.
- [x] `pnpm turbo lint` passes.
- [ ] Post-merge: re-trigger Publish on main → release job progresses through smoke test, publishes `@1.0.2` on npm `@latest`.

## Risk

**Very low.** Loosens a check from "must be function" to "must be function or object". Catches fewer false positives.

## Rollback

Revert the merge commit. Smoke test fails again on object exports.

🤖 Generated with [Claude Code](https://claude.com/claude-code)