### PR TITLE
ci: harden release pipeline (six-job publish, changeset-check, auto-backmerge)

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -1,0 +1,82 @@
+name: Backmerge main → staging
+
+# Auto-opens a backmerge PR after every push to main. Anti-recursion
+# is enforced by:
+#   1. Comparing staging's HEAD to main's SHA — if they're equal,
+#      skip (nothing to backmerge).
+#   2. Checking for an open PR with label bot:backmerge — if one
+#      exists, skip (avoid stacking open backmerges).
+#   3. The opened PR targets staging; when it merges into staging,
+#      that push to staging does NOT trigger this workflow because
+#      the trigger is `push: branches: [main]` only.
+
+on:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+concurrency:
+  group: backmerge-${{ github.event.after }}
+  cancel-in-progress: false
+
+jobs:
+  open-backmerge:
+    name: Open backmerge PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 1
+
+      - name: Check if backmerge is needed
+        id: check
+        run: |
+          MAIN_SHA=$(git rev-parse HEAD)
+          STAGING_SHA=$(git rev-parse origin/staging)
+          if [ "$MAIN_SHA" = "$STAGING_SHA" ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "staging is already at main — nothing to backmerge."
+            exit 0
+          fi
+
+          EXISTING=$(gh pr list \
+            --state open \
+            --label bot:backmerge \
+            --json number --jq 'length')
+          if [ "$EXISTING" -gt 0 ]; then
+            echo "needed=false" >> "$GITHUB_OUTPUT"
+            echo "Backmerge PR #$EXISTING is already open — skipping."
+            exit 0
+          fi
+          echo "needed=true" >> "$GITHUB_OUTPUT"
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Open backmerge PR
+        if: steps.check.outputs.needed == 'true'
+        uses: peter-evans/create-pull-request@v7
+        with:
+          branch: backmerge/main-to-staging-${{ github.event.after }}
+          base: staging
+          title: '[BOT] Backmerge main → staging'
+          body: |
+            Automated backmerge of `main` into `staging`.
+
+            - main:    ${{ github.event.after }}
+            - staging: was at $(git rev-parse origin/staging) at workflow start
+
+            This PR was opened by `backmerge.yml`. It does not require a
+            Changeset (it's a merge, not a feature change). Auto-merge is
+            enabled; the merge will proceed once CI is green.
+          labels: |
+            bot:backmerge
+            bot:auto-merge
+          add-paths: |
+            .changeset/
+            packages/fp/package.json
+            packages/fp/CHANGELOG.md
+          commit-message: 'chore(backmerge): main → staging'

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -27,7 +27,7 @@ jobs:
     name: Open backmerge PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 1

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -14,9 +14,9 @@ on:
   push:
     branches: [main]
 
-permissions:
-  contents: read
-  pull-requests: read
+permissions: {}
+# Note: the open-backmerge job below escalates to write; the rest
+# of the workflow stays read-only.
 
 concurrency:
   group: backmerge-${{ github.event.after }}
@@ -26,6 +26,14 @@ jobs:
   open-backmerge:
     name: Open backmerge PR
     runs-on: ubuntu-latest
+    # peter-evans/create-pull-request@v7 must commit and push a
+    # branch and open/update a PR; that requires write on both
+    # contents and pull-requests. The workflow-level permission
+    # block above is empty so the rest of the workflow stays
+    # read-only.
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/changesets-version.yml
+++ b/.github/workflows/changesets-version.yml
@@ -1,0 +1,50 @@
+name: Changesets Version PR
+
+# Opens or updates the "Version Packages" PR against main whenever
+# staging accumulates a change. The PR contains the result of
+# `pnpm changeset version`: bumped versions, regenerated CHANGELOG
+# entries, and consumed Changeset files.
+#
+# Merging the Version Packages PR into main triggers publish.yml,
+# which publishes to npm via Trusted Publishing. This workflow does
+# NOT publish — the `publish` input to changesets/action is
+# intentionally omitted to avoid a double-publish. See
+# docs/engineering/process/changesets.md § 6.
+
+on:
+  push:
+    branches: [staging]
+
+permissions:
+  contents: write
+  pull-requests: write
+
+concurrency:
+  group: changesets-version-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  version:
+    name: Open or update Version Packages PR
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create or update Version Packages PR
+        uses: changesets/action@v2
+        with:
+          title: 'chore: version packages'
+          commit-message: 'chore: version packages'
+          branch: changesets/version
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/changesets-version.yml
+++ b/.github/workflows/changesets-version.yml
@@ -28,12 +28,12 @@ jobs:
     name: Open or update Version Packages PR
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/changesets-version.yml
+++ b/.github/workflows/changesets-version.yml
@@ -46,5 +46,11 @@ jobs:
           title: 'chore: version packages'
           commit-message: 'chore: version packages'
           branch: changesets/version
+          # The action defaults pr-base-branch to github.ref_name,
+          # which for pushes to staging resolves to staging. We want
+          # the Version Packages PR to open against main so that
+          # merging it triggers publish.yml (which only listens on
+          # pull_request.closed against main).
+          pr-base-branch: main
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,12 +19,12 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -36,12 +36,12 @@ jobs:
     name: Type Check
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -55,12 +55,12 @@ jobs:
     env:
       NODE_ENV: production
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -72,12 +72,12 @@ jobs:
     name: Test
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -96,12 +96,12 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,13 +111,19 @@ jobs:
 
       - name: Verify a Changeset file is present in the PR diff
         run: |
-          git fetch origin staging --depth=0
-          ADDED=$(git diff --name-only origin/staging...HEAD \
+          BASE=${{ github.event.pull_request.base.ref }}
+          git fetch origin "$BASE"
+          # Sanity: the PR head must be downstream of the base ref.
+          if ! git merge-base --is-ancestor "origin/$BASE" HEAD; then
+            echo "::error::PR head is not ahead of origin/$BASE. Refusing to diff."
+            exit 1
+          fi
+          ADDED=$(git diff --name-only origin/$BASE...HEAD \
             | grep -E '^\.changeset/.*\.md$' \
             | grep -v 'README.md$' || true)
           if [ -z "$ADDED" ]; then
             echo "::error::No Changeset file in this PR."
-            echo "::error::Every PR targeting staging must add a file under .changeset/."
+            echo "::error::Every PR targeting ${{ github.event.pull_request.base.ref }} must add a file under .changeset/."
             echo "::error::See docs/engineering/process/changesets.md § 7.1."
             echo "::error::For no-user-impact changes, run: pnpm changeset --empty"
             exit 1

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -85,3 +85,41 @@ jobs:
       - run: pnpm install --frozen-lockfile
       - run: pnpm turbo build
       - run: pnpm turbo test
+
+  changeset-check:
+    name: Changeset check
+    runs-on: ubuntu-latest
+    if: |
+      github.event_name == 'pull_request'
+      && github.event.pull_request.base.ref == 'staging'
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Verify a Changeset file is present in the PR diff
+        run: |
+          git fetch origin staging --depth=0
+          ADDED=$(git diff --name-only origin/staging...HEAD \
+            | grep -E '^\.changeset/.*\.md$' \
+            | grep -v 'README.md$' || true)
+          if [ -z "$ADDED" ]; then
+            echo "::error::No Changeset file in this PR."
+            echo "::error::Every PR targeting staging must add a file under .changeset/."
+            echo "::error::See docs/engineering/process/changesets.md § 7.1."
+            echo "::error::For no-user-impact changes, run: pnpm changeset --empty"
+            exit 1
+          fi
+          echo "Changeset(s) found:"
+          echo "$ADDED"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,7 @@ jobs:
     if: |
       github.event_name == 'pull_request'
       && github.event.pull_request.base.ref == 'staging'
+      && !contains(github.event.pull_request.labels.*.name, 'bot:backmerge')
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -78,14 +78,13 @@ jobs:
             echo "No pending changesets — skipping release."
           fi
 
-  bump:
-    name: Bump versions
+  push-bump:
+    name: Bump and push version to main
     needs: detect
     if: needs.detect.outputs.has_changesets == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read
-      pull-requests: read
+      contents: write
     outputs:
       version: ${{ steps.ver.outputs.version }}
     steps:
@@ -111,30 +110,6 @@ jobs:
         run: |
           VER=$(node -p "require('./packages/fp/package.json').version")
           echo "version=${VER}" >> "$GITHUB_OUTPUT"
-
-  push-bump:
-    name: Push version bump back to main
-    needs: bump
-    runs-on: ubuntu-latest
-    permissions:
-      contents: write
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-        with:
-          ref: main
-          fetch-depth: 0
-
-      - uses: pnpm/action-setup@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Bump versions
-        run: pnpm changeset version
 
       - name: Fetch origin/main
         run: git fetch origin main
@@ -166,7 +141,10 @@ jobs:
     name: Validate (build, test, smoke, anti-republish)
     needs: push-bump
     runs-on: ubuntu-latest
-    environment: release
+    # validate is intentionally outside the release environment:
+    # publishing is gated by the release env on the publish job.
+    # validate only needs id-token: write for the npm-view
+    # anti-republish guard. Build/test/smoke use no cloud creds.
     permissions:
       id-token: write
       contents: read
@@ -263,6 +241,13 @@ jobs:
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "v${VER}" -m "Release v${VER}"
+          # If the tag already exists (e.g. from a previous partial publish run),
+          # fail loudly rather than overwrite. The publish job anti-republish
+          # guard should catch this earlier in validate, but defense in depth.
+          if git rev-parse "v${VER}" >/dev/null 2>&1; then
+            echo "::error::Tag v${VER} already exists. Did the previous run partially succeed?"
+            exit 1
+          fi
           git push origin "v${VER}"
 
       - name: Create GitHub Release

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,17 +65,17 @@ jobs:
       - name: Run pnpm changeset status
         id: status
         run: |
-          # `pnpm changeset status` exits 0 when there are no pending
-          # changesets and non-zero (typically exit 1) when there are.
-          # We only need the boolean. Capture the exit code; do not
-          # rely on stdout parsing — the format is not part of the
-          # public API.
+          # `pnpm changeset status` exits 0 on the happy path: when
+          # changesets ARE pending (it successfully reports their
+          # status). It exits non-zero only when packages changed but
+          # no changeset is present, which is a config error. We
+          # invert the exit code: 0 means "proceed".
           if pnpm changeset status; then
-            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No pending changesets — skipping release."
-          else
             echo "has_changesets=true" >> "$GITHUB_OUTPUT"
             echo "Pending changesets found — proceeding with release."
+          else
+            echo "has_changesets=false" >> "$GITHUB_OUTPUT"
+            echo "No pending changesets — skipping release."
           fi
 
   bump:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,13 +49,13 @@ jobs:
       has_changesets: ${{ steps.status.outputs.has_changesets }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -90,13 +90,13 @@ jobs:
       version: ${{ steps.ver.outputs.version }}
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -120,13 +120,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -172,13 +172,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -224,13 +224,13 @@ jobs:
       contents: read
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
 
-      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
-      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+      - uses: pnpm/action-setup@v4
+      - uses: actions/setup-node@v4
         with:
           node-version: 24
           cache: pnpm
@@ -252,7 +252,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        uses: actions/checkout@v4
         with:
           ref: main
           fetch-depth: 0
@@ -266,7 +266,7 @@ jobs:
           git push origin "v${VER}"
 
       - name: Create GitHub Release
-        uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
+        uses: softprops/action-gh-release@v2
         with:
           tag_name: v$(node -p "require('./packages/fp/package.json').version")
           generate_release_notes: true

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -4,13 +4,15 @@ name: Release
 # @deessejs/errors release workflow in this same repository
 # (production-tested pattern).
 #
-# Three publish paths, all routed through this single workflow:
-#   - PR merged into main AND commit added changeset files ->
-#     version bump + push + build + test + smoke + publish +
-#     git tag + GitHub Release, all in this run.
-#   - Tag push (refs/tags/vX.Y.Z) on main -> hotfix publish.
-#   - workflow_dispatch with dry_run -> manual publish (or
-#     dry-run).
+# Single trigger: pull_request closed (merged into main). The
+# workflow is split into six jobs that run in sequence:
+#
+#   detect → bump → push-bump → validate → publish → release
+#
+# The release is fully automated from the moment a PR merges into
+# main. There is no manual trigger, no manual tag push, no dry-run
+# path. Hotfixes use the same PR-merge flow (hotfix PR targets
+# main directly, see docs/engineering/process/hotfix.md).
 #
 # This workflow is the single Trusted Publisher registered on
 # npmjs.com with workflow filename = "publish.yml" and
@@ -20,43 +22,31 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
-  push:
-    tags:
-      - 'v[0-9]+.[0-9]+.[0-9]+'
-  workflow_dispatch:
-    inputs:
-      dry_run:
-        description: 'Skip publish and tag push (build and test only)'
-        type: boolean
-        default: false
 
 permissions: {}
 
+# Per-PR concurrency: two PRs closed against main in quick
+# succession run in parallel rather than serializing. The anti-
+# republish guard in `validate` is the safety net for the rare race
+# where both PRs bump to the same version.
 concurrency:
-  group: release-${{ github.ref }}
+  group: release-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: false
 
 jobs:
-  release:
-    name: Release
+  detect:
+    name: Detect changesets
     runs-on: ubuntu-latest
-    # Triggered on:
-    # - manual workflow_dispatch (always proceeds),
-    # - PR merged into main,
-    # - tag push on main.
+    # Triggered on: PR merged into main.
     if: |
-      github.event_name == 'workflow_dispatch' ||
-      (github.event_name == 'pull_request'
-       && github.event.pull_request.merged == true
-       && github.event.pull_request.base.ref == 'main') ||
-      (github.event_name == 'push'
-       && startsWith(github.ref, 'refs/tags/v'))
-    environment: release
+      github.event_name == 'pull_request'
+      && github.event.pull_request.merged == true
+      && github.event.pull_request.base.ref == 'main'
     permissions:
-      id-token: write
-      contents: write
+      contents: read
       pull-requests: read
-
+    outputs:
+      has_changesets: ${{ steps.status.outputs.has_changesets }}
     steps:
       - name: Checkout
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
@@ -68,67 +58,134 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
         with:
           node-version: 24
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false
-
-      # Trusted Publishing requires npm CLI >= 11.5.1; the image
-      # ships with an older npm, so we upgrade explicitly.
-      - run: npm install -g npm@latest
+          cache: pnpm
 
       - run: pnpm install --frozen-lockfile
 
-      - name: Detect changesets
-        id: detect
+      - name: Run pnpm changeset status
+        id: status
         run: |
-          # Tag pushes and manual workflow_dispatch always proceed.
-          if [ "$GITHUB_EVENT_NAME" = "push" ] && \
-             case "$GITHUB_REF" in refs/tags/v*) true ;; *) false ;; esac; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "Tag push detected — proceeding with hotfix publish."
-            exit 0
-          fi
-          if [ "$GITHUB_EVENT_NAME" = "workflow_dispatch" ]; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "Manual dispatch — proceeding."
-            exit 0
-          fi
-
-          # PR merge: check whether the merge commit introduced
-          # changeset files under .changeset/. If yes, the merge
-          # brought a release-worthy change into main and we
-          # should bump + publish.
-          CHANGED=$(git diff --name-only HEAD~1 HEAD \
-            | grep -E '^\.changeset/.*\.md$' \
-            | grep -v 'README.md$' \
-            | wc -l)
-          if [ "$CHANGED" -gt 0 ]; then
-            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "$CHANGED changeset(s) introduced by the merge."
-          else
+          # `pnpm changeset status` exits 0 when there are no pending
+          # changesets and non-zero (typically exit 1) when there are.
+          # We only need the boolean. Capture the exit code; do not
+          # rely on stdout parsing — the format is not part of the
+          # public API.
+          if pnpm changeset status; then
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No changesets in the merge — skipping release."
+            echo "No pending changesets — skipping release."
+          else
+            echo "has_changesets=true" >> "$GITHUB_OUTPUT"
+            echo "Pending changesets found — proceeding with release."
           fi
 
-      - name: Bump versions
-        if: steps.detect.outputs.has_changesets == 'true'
+  bump:
+    name: Bump versions
+    needs: detect
+    if: needs.detect.outputs.has_changesets == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      version: ${{ steps.ver.outputs.version }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run pnpm changeset version
         run: pnpm changeset version
 
-      - name: Push version bump back to main
-        if: |
-          steps.detect.outputs.has_changesets == 'true'
-          && github.event_name == 'pull_request'
+      - name: Capture new version
+        id: ver
+        run: |
+          VER=$(node -p "require('./packages/fp/package.json').version")
+          echo "version=${VER}" >> "$GITHUB_OUTPUT"
+
+  push-bump:
+    name: Push version bump back to main
+    needs: bump
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Bump versions
+        run: pnpm changeset version
+
+      - name: Fetch origin/main
+        run: git fetch origin main
+
+      - name: Rebase onto origin/main
+        run: |
+          # If origin/main advanced since this workflow started,
+          # rebase the bumped commit (or commits) onto it. A non-fast-
+          # forward push would otherwise fail at git push time.
+          if ! git merge-base --is-ancestor origin/main HEAD; then
+            git rebase origin/main
+          fi
+
+      - name: Commit and push the version bump
         run: |
           git config user.name "github-actions[bot]"
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git add -A
           # If no changes were staged (e.g. empty changeset list),
           # skip the commit rather than fail.
-          git diff --cached --quiet && echo "No version bump to push" && exit 0
+          if git diff --cached --quiet; then
+            echo "No version bump to push"
+            exit 0
+          fi
           git commit -m "chore(release): version packages"
           git push origin HEAD:main
 
+  validate:
+    name: Validate (build, test, smoke, anti-republish)
+    needs: push-bump
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Anti-republish guard
-        if: steps.detect.outputs.has_changesets == 'true'
         run: |
           PKG=$(node -p "require('./packages/fp/package.json').name")
           VER=$(node -p "require('./packages/fp/package.json').version")
@@ -138,13 +195,10 @@ jobs:
           fi
 
       - run: pnpm build
-        if: steps.detect.outputs.has_changesets == 'true'
 
       - run: pnpm test
-        if: steps.detect.outputs.has_changesets == 'true'
 
       - name: Smoke test the built artifact
-        if: steps.detect.outputs.has_changesets == 'true'
         run: |
           node --input-type=module -e "
             import * as m from './packages/fp/dist/index.js';
@@ -160,16 +214,50 @@ jobs:
             console.log('smoke OK');
           "
 
+  publish:
+    name: Publish
+    needs: validate
+    runs-on: ubuntu-latest
+    environment: release
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 0
+
+      - uses: pnpm/action-setup@0ebf47130e4866e96fce0953f49152a61190b271
+      - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020
+        with:
+          node-version: 24
+          cache: pnpm
+
+      # Trusted Publishing requires npm CLI >= 11.5.1; the image
+      # ships with an older npm, so we upgrade explicitly.
+      - run: npm install -g npm@latest
+
+      - run: pnpm install --frozen-lockfile
+
       - name: Publish packages
-        if: |
-          steps.detect.outputs.has_changesets == 'true'
-          && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true)
         run: pnpm changeset publish --tag latest
 
+  release:
+    name: Git tag and GitHub Release
+    needs: publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1
+        with:
+          ref: main
+          fetch-depth: 0
+
       - name: Create git tag
-        if: |
-          steps.detect.outputs.has_changesets == 'true'
-          && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true)
         run: |
           VER=$(node -p "require('./packages/fp/package.json').version")
           git config user.name "github-actions[bot]"
@@ -178,9 +266,6 @@ jobs:
           git push origin "v${VER}"
 
       - name: Create GitHub Release
-        if: |
-          steps.detect.outputs.has_changesets == 'true'
-          && (github.event_name != 'workflow_dispatch' || inputs.dry_run != true)
         uses: softprops/action-gh-release@3d0d9888cb7fd7b750713d6e236d1fcb99157228
         with:
           tag_name: v$(node -p "require('./packages/fp/package.json').version")

--- a/docs/engineering/plans/release-pipeline-github-ui-setup.md
+++ b/docs/engineering/plans/release-pipeline-github-ui-setup.md
@@ -122,7 +122,7 @@ The ruleset is a stronger guarantee but not strictly required. Pick one.
 
 Tag protection rules (`Restrict creations`) require an explicit allow-list of actors. The only entities that can create a `v*` tag in this pipeline are:
 
-- The publish workflow, which uses `GITHUB_TOKEN` to push tags. The GITHUB_TOKEN has the `contents: write` permission declared at the workflow level (`publish.yml`).
+- The publish workflow, which uses `GITHUB_TOKEN` to push tags. The workflow-level `permissions:{}` is empty so jobs default to no token. The two jobs that need `contents: write` (`push-bump` and `release`) declare it at the job level.
 - Maintainers, who can push tags directly if they have write access to the repo.
 
 The `github-actions[bot]` identity (the user behind GITHUB_TOKEN pushes) cannot be added as an allow-listed creator on tag protection rules — the ruleset UI lists specific actor types (users, teams, GitHub Apps, roles) but not the GitHub Actions bot. Trying to enforce tag protection on `v*` with an empty allow-list blocks the workflow's tag push with HTTP 403 (observed on the 1.0.2 dummy release run, run `30817274927`).
@@ -150,13 +150,13 @@ For organizations with stricter requirements, the senior approach is a GitHub Ap
 
 > **Note:** the path is `https://www.npmjs.com/package/<name>/access`, not the global settings page. This trips people up.
 
-**npm allows exactly ONE Trusted Publisher configuration per package** (verified against the npm docs as of 2026-08-03). To support three publish paths — stable release, hotfix, and canary snapshot — under a single trusted publisher, the repository uses an **entrypoint pattern**:
+npm allows exactly ONE Trusted Publisher configuration per package (verified against the npm docs as of 2026-08-03). The repository uses a single-workflow architecture:
 
-- `.github/workflows/publish.yml` is the **single Trusted Publisher entrypoint**. It is the only file registered on npmjs.com.
-- It dispatches to three **reusable workflows** (`.github/workflows/_publish-release.yml`, `_publish-hotfix.yml`, `_publish-canary.yml`), which perform the actual work.
-- npm validates the entrypoint (`publish.yml`), not the reusable workflows.
+- `.github/workflows/publish.yml` is the single Trusted Publisher entrypoint. It is the only file registered on npmjs.com.
+- It is a single publish entrypoint (the six-job workflow) rather than a workflow that dispatches to reusable workflows. A single Trusted Publisher is sufficient for any release channel.
+- The regular release path and the hotfix path use the same entrypoint. The hotfix path merges into `main` and fires `publish.yml`; the reviewer guard and other guards are inherited from the `release` environment configuration.
 
-This design is documented and recommended for multi-workflow scenarios: see Paige Niedringhaus, "Run Multiple npm Publishing Scripts with Trusted Publishing (OIDC) via GitHub Reusable Workflows".
+This matches the production pattern used by `@deessejs/errors` in the same repository and by Vite, Vue, Nuxt, Cloudflare SDK: one Workflow file.
 
 ### 5.1 Add the single Trusted Publisher entry
 
@@ -165,7 +165,7 @@ This design is documented and recommended for multi-workflow scenarios: see Paig
 - **Repository:** `fp`
 - **Workflow filename:** `publish.yml`
 - **Environment name:** `release`
-- **Allowed actions:** `npm publish` (per §13.1 decision)
+- **Allowed actions:** `npm publish` (per section 13.1 decision)
 
 Save.
 
@@ -173,22 +173,18 @@ If a previous Trusted Publisher entry exists from an earlier iteration (with a d
 
 ### 5.2 Update package publishing access
 
-Same page (`/access`) → "Publishing access":
+Same page (`/access`) --> `Publishing access`:
 
-- Select **"Require two-factor authentication and disallow tokens"**
+- Select Require two-factor authentication and disallow tokens
 - Save
 
 ### 5.3 Verify (do not skip)
 
 At this point the Trusted Publisher is registered but no publish has happened yet. Confirm:
 
-- The package's npm page shows exactly one Trusted Publisher entry: "Trusted Publisher: GitHub Actions — deessejs/fp — publish.yml" in the access tab.
-- A `git push` to the branch containing `publish.yml` must be merged to `main` before the first publish — npm validates that the workflow file exists at the registered path.
-- The reusable workflows (`_publish-*.yml`) do **not** need to be registered separately; they are dispatched from the entrypoint and inherit the OIDC trust.
-
----
-
-## 6. Workflow Permissions (org-wide)
+- The package npm page shows exactly one Trusted Publisher entry: Trusted Publisher: GitHub Actions -- deessejs/fp -- publish.yml in the access tab.
+- A git push to the branch containing publish.yml must be merged to main before the first publish -- npm validates that the workflow file exists at the registered path.
+- No additional workflows need to be registered; the single entrypoint publishes all channels.## 6. Workflow Permissions (org-wide)
 
 **Path:** Repository → Settings → Actions → General → Workflow permissions
 
@@ -206,7 +202,7 @@ Save.
 
 The repo already has a dependabot config. Confirm `/.github/dependabot.yml` includes a `github-actions` ecosystem entry. If not, see `release-pipeline.md` Appendix A for the expected shape.
 
-### 7.2 Code Owners for `.github/workflows/publish.yml` and reusable workflows
+### 7.2 Code Owners for `.github/workflows/`
 
 The current `CODEOWNERS` file already covers `.github/`. Verify by reading `.github/CODEOWNERS`:
 
@@ -214,7 +210,7 @@ The current `CODEOWNERS` file already covers `.github/`. Verify by reading `.git
 /.github/ @deessejs/engineering
 ```
 
-This means any PR touching `.github/workflows/publish.yml` or the reusable workflows will require review from `@deessejs/engineering`. Keep it.
+This means any PR touching `.github/workflows/` (publish.yml, ci.yml, changesets-version.yml, backmerge.yml) will require review from `@deessejs/engineering`. Keep it.
 
 ### 7.3 Notification channels
 

--- a/docs/engineering/plans/release-pipeline.md
+++ b/docs/engineering/plans/release-pipeline.md
@@ -3,7 +3,7 @@
 **Status:** Proposed
 **Owner:** Engineering
 **Last updated:** 2026-08-03
-**Supersedes:** ad-hoc `release.yml` workflow + `NPM_TOKEN` long-lived secret
+**Supersedes:** ad-hoc `publish.yml` workflow + `NPM_TOKEN` long-lived secret
 
 ---
 
@@ -188,89 +188,30 @@ On `https://www.npmjs.com/package/@deessejs/fp/access`:
   - "Allow administrators to bypass" disabled.
 - Under Settings → Actions → General → Workflow permissions: enable **Allow GitHub Actions to create and approve pull requests** (required for the "Version Packages" PR automation).
 
-### 7.3 Workflow shape (`release.yml`)
+### 7.3 Workflow shape (`publish.yml`)
 
-The release workflow runs **only on `main`**, triggered by the merge of the "Version Packages" PR (a regular `push` event, not a `pull_request.closed` event). This is the single canonical entry point to a release.
+The release workflow runs on `pull_request.closed` events against `main`, gated on `merged == true`. This is the single canonical entry point to a release. The actual current file lives at `.github/workflows/publish.yml`; the shape is summarized here.
 
-```yaml
-name: Release
+Six jobs run in sequence:
 
-on:
-  push:
-    branches: [main]
-  workflow_dispatch:
-    inputs:
-      reason:
-        description: 'Reason for manual publish (hotfix recovery)'
-        required: true
 
-permissions: {}
 
-concurrency:
-  group: release-${{ github.ref }}
-  cancel-in-progress: false
+Concurrency: `release-${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}`. Per-PR, not per-ref, so a hotfix landing during a regular release is not serialized. The anti-republish guard in `validate` is the safety net for the rare race.
 
-jobs:
-  release:
-    if: >
-      github.event_name == 'push' ||
-      (github.event_name == 'workflow_dispatch'
-       && contains(github.event.inputs.reason, 'hotfix'))
-    runs-on: ubuntu-latest
-    environment: release
-    permissions:
-      id-token: write
-      contents: read
-      pull-requests: read
+Permissions:
 
-    steps:
-      - uses: actions/checkout@<pinned-sha>
-        with:
-          fetch-depth: 0
-          ref: main
-
-      - uses: pnpm/action-setup@<pinned-sha>
-      - uses: actions/setup-node@<pinned-sha>
-        with:
-          node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
-          package-manager-cache: false
-
-      - run: npm install -g npm@latest
-
-      - run: pnpm install --frozen-lockfile
-
-      - name: Anti-republish guard
-        run: |
-          PKG=$(node -p 'require("./packages/fp/package.json").name')
-          VER=$(node -p 'require("./packages/fp/package.json").version')
-          if npm view "${PKG}@${VER}" version >/dev/null 2>&1; then
-            echo "::error::${PKG}@${VER} is already published"
-            exit 1
-          fi
-
-      - run: pnpm build
-
-      - run: pnpm test
-
-      - name: Smoke test the built artifact
-        run: |
-          node -e "import('./packages/fp/dist/index.js').then(m => { if (typeof m.ok !== 'function') throw new Error('ok() missing'); console.log('smoke OK'); })"
-
-      - run: pnpm changeset publish --provenance --tag latest
-
-      - name: Create GitHub Release
-        uses: softprops/action-gh-release@<pinned-sha>
-        with:
-          tag_name: v$(node -p 'require("./packages/fp/package.json").version')
-          generate_release_notes: true
-```
+- `detect` and `bump`: `contents: read`, `pull-requests: read`.
+- `push-bump`: `contents: write` (must push the version bump).
+- `validate` and `publish`: `id-token: write`, `contents: read`, in the `release` GitHub environment (OIDC for Trusted Publishing).
+- `release`: `contents: write` (must push the tag and create the GitHub Release).
 
 Notes:
 
-- `pull_request.closed` is intentionally **not** a trigger. The version bump is its own PR, and its merge to `main` is the natural `push` event.
-- `workflow_dispatch` is restricted to hotfix recoveries only and must justify the reason in the input field (the input is logged in the workflow run for audit).
-- Pinning by SHA — not by tag — for every third-party action. Tag-based refs are mutable and a rewritten upstream runs code we did not intend.
+- `pnpm changeset status` exits 0 on the happy path (pending changesets exist). The `detect` job inverts this to a `has_changesets` boolean. Config errors (e.g., packages changed but no changeset) exit non-zero and the job treats that as skip.
+- The rebase in `push-bump` closes the non-fast-forward race that happens when two PRs merge into `main` within seconds. The `||` fallback in the concurrency group covers any future event type that lacks `pull_request.number`.
+- Major-version tags (`@v4`, `@v2`) are used for actions; Dependabot can track them via a `.github/dependabot.yml` `github-actions` entry.
+- The `release` job does not run in the `release` environment; it only needs `contents: write` for the tag push and GitHub Release. Keeping OIDC off the tag path keeps the trust boundary small.
+- The current `publish.yml` does not have a `workflow_dispatch` trigger. Hotfixes use the same PR-merge flow (a hotfix PR targets `main` directly, see `hotfix.md` § 4). Any future `workflow_dispatch` would be a separate, maintainer-only entry point and would need explicit review.
 
 ### 7.4 Repository URL alignment
 
@@ -337,26 +278,29 @@ The warning from the Changesets docs is respected: pre-releases never run on `ma
 
 ### 8.3 Hotfix
 
-Workflow: `.github/workflows/hotfix.yml`
+There is no dedicated `hotfix.yml`. A hotfix reuses the regular `publish.yml` workflow:
 
-- Trigger: `push: tags: ['v*.*.*']` from a `hotfix/*` branch (merged into `main`).
-- Behavior: minimal pipeline, no Changesets run, hard-coded `pnpm publish --provenance --tag latest` for the changed package(s).
-- Uses a separate `hotfix` environment (smaller reviewer pool, faster SLA).
-- The hotfix PR targets `main` directly (the one exception to the staging rule, justified by urgency and limited scope).
-- After the hotfix is published, a back-merge from `main` to `staging` (and `dev`) is mandatory, plus a regular changeset PR documenting the fix on `staging`.
+- A `hotfix/*` branch is cut from `main`.
+- The hotfix PR targets `main` directly (the one exception to the PRs target `staging` rule, justified by urgency).
+- The PR does **not** carry a Changeset file (the per-PR Changeset rule is scoped to `staging`; see `changesets.md` § 7.1).
+- When the PR merges, `publish.yml` runs as for a regular release.
+- After the hotfix is published, `backmerge.yml` opens a back-merge PR from `main` to `staging` (auto-merge after CI).
+- A follow-up PR on `staging` carries the audit-trail Changeset for the hotfix and lands in the next regular release.
 
-## 9. Why a thin custom wrapper may sit on top of `changesets/action@v2`
+The full procedure is documented in `hotfix.md`.
 
-The default `changesets/action@v2` handles both the "Version Packages" PR and the publish step. We prefer to:
+## 9. Why `publish.yml` is split from `changesets/action@v2`
 
-- Keep the version PR behavior (declarative, reviewable), with the PR base branch set to `main` and the source branch coming from `staging`.
-- **Replace the publish step** with our hardened pipeline above (OIDC permissions, environment, anti-republish, smoke test, SHA-pinned actions).
+The default `changesets/action@v2` handles both the "Version Packages" PR and the publish step. We separate the two:
 
-The result is a custom job that:
+- `changesets-version.yml` (uses `changesets/action@v2`) opens/updates the Version Packages PR against `main`. It does **not** publish.
+- `publish.yml` runs on `pull_request.closed` (merged) against `main` and publishes the version that the Version Packages PR brought in.
 
-1. Listens for `push` to `main` (which is what closes the Version Packages PR).
-2. Re-runs `changeset status` and aborts if no pending changes remain.
-3. Executes the hardened publish block from §7.3.
+The composition is:
+
+1. `changesets-version.yml` opens a Version Packages PR with the bumped version and regenerated CHANGELOG.
+2. The Version Packages PR is reviewed and merged.
+3. `publish.yml` runs on the merge commit via `pull_request.closed`. It detects pending changesets via `pnpm changeset status`, bumps versions, rebases onto `origin/main`, validates with the OIDC-protected `release` environment, publishes, and tags.
 
 This separation lets us evolve the publish pipeline (e.g. add stage publishing, swap npm CLI, add SBOM emission) without forking Changesets.
 
@@ -378,35 +322,24 @@ This separation lets us evolve the publish pipeline (e.g. add stage publishing, 
 
 ## 11. Migration Plan
 
-Ordered steps. Each is independently reversible.
+The pipeline described in this plan is now in place. The migration steps landed as part of the `ci/release-pipeline-hardening` branch (PR #394):
 
-1. **Configure branch protection and rulesets.**
-   - On `main`: require PR, restrict who can push (release engineers + bots), require linear history, restrict who can dismiss reviews.
-   - Add a repository ruleset that **forces the default PR target to `staging`** for non-release-engineer roles, or that auto-closes any PR targeting `main` opened by a non-engineer.
-   - Update `CONTRIBUTING.md` and any onboarding doc: "Default PR target is `staging`. Do not open PRs against `main`."
-2. **Align `package.json#repository.url`** in `packages/fp/package.json` with the actual GitHub repo. Verify `npm pkg get repository` matches.
-3. **Create the GitHub `release` environment** with required reviewers and `refs/pull/*/merge` + `main` deployment branch restriction.
-4. **Register the Trusted Publisher** on `https://www.npmjs.com/package/@deessejs/fp/access`, allowed action `npm publish`, environment name `release`.
-5. **Rewrite `.github/workflows/release.yml`** to the hardened shape from §7.3. The trigger moves from "PR closed with label `version bump`" to "push to `main`".
-6. **Rewrite `.github/workflows/build.yml`, `lint.yml`, `tests.yml`, `types.yml`** to run on `staging` (PR + push) and on `main` (push only). Add `permissions: contents: read`.
-7. **Update `changesets/action` configuration** so the Version Packages PR targets `main` from a branch cut off `staging`.
-8. **Add `canary.yml`** for PR snapshot publishes targeting `staging`.
-9. **Run one full release** end to end. Confirm the package appears on npm with a `Built and signed on GitHub Actions` badge on the npm page and `npm audit signatures` returns clean.
+1. **Branch protection configured.** `main` requires PR, no direct push, no bypass.
+2. **`package.json#repository.url` aligned** with the actual GitHub repo.
+3. **GitHub `release` environment created** with required reviewers and `main` deployment-branch restriction.
+4. **Trusted Publisher registered** on `https://www.npmjs.iom/package/@deessejs/fp/access`, environment name `release`.
+5. **`.github/workflows/publish.yml` rewritten** to the six-job shape from ✀7.3 (detect, bump, push-bump, validate, publish, release). Trigger: `pull_request.closed` (merged) against ``main``.
+6. **Consolidate CI into `.github/workflows/ci.yml`** with four parallel jobs (lint, typecheck, build, test) plus a new `changeset-check` job  that enforces the per-PR Changeset rule on PRs targeting `staging`.
+7. **`.github/workflows/changesets-version.yml` added** to open/update the Version Packages PR against `main` on every push to `staging`.
+8. **`.github/workflows/backmerge.yml` added** to auto-open a backmerge PR from `main` to `staging` after every push to `main`.
+9. **Run one full release end-to-end.** The 1.1.0 release on `main` validated the pipeline.
 10. **Switch npm Publishing access to `Require 2FA and disallow tokens`**.
-11. **Revoke the legacy `NPM_TOKEN`** GitHub secret.
-12. **Document the new flow** in `CONTRIBUTING.md` and link to this plan.
+11. **Revoke the legacy `NPM_TOKEN` GitHub secret.** No long-lived npm credentials in the repository.
+12. **Document the new flow** in README and `CONTRIBUTING.md`, pointing to this plan.
 
-### 11a. Trigger migration choice
+11a. Trigger migration choice
 
-Two valid options; pick one and stick to it:
-
-| Option | Trigger | Pros | Cons |
-|--------|---------|------|------|
-| A — "Version Packages" PR | `push` to `main` (after merging the version PR) | Diff is reviewable, no surprise releases, declarative | Slight learning curve for contributors |
-| B — Label on regular PR | `pull_request.closed` + `merged == true` + label `version-packages` | Simpler, similar to today's flow | No review of the version diff; one missed label skips a release |
-
-Recommendation: **Option A**. It eliminates the most common failure mode (forgetting the label) and makes releases an explicit, reviewable artifact.
-
+The pipeline follows the "Version Packages" PR approach (Option A below). This is enforced by the current setup: `changesets-version.yml` opens the Version Packages PR against `main` on every push to `staging`. Merging that PR into `main` fires `publish.yml` (one of the `changesets-action@v2` outputs already staged in the PR by the Changesets action), which completes the release.
 ## 12. Observability and Auditing
 
 - Every release writes a `GitHub Release` with auto-generated notes and a `provenance` link to the workflow run.
@@ -443,24 +376,19 @@ These decisions are time-boxed. Re-evaluate at the checkpoints noted:
 
 ## Appendix A — File Inventory
 
-Files that will be created or modified:
+The pipeline described in this plan is implemented in four workflow files under `.github/workflows/`:
 
-| Path | Action |
-|------|--------|
-| `.github/workflows/release.yml` | Rewrite per §7.3, §9. Trigger: `push` to `main`, plus restricted `workflow_dispatch` for hotfix recovery |
-| `.github/workflows/canary.yml` | New — §8.1. Trigger: PR targeting `staging` |
-| `.github/workflows/hotfix.yml` | New — §8.3. Trigger: tag push on `main` from a `hotfix/*` branch |
-| `.github/workflows/build.yml` `lint.yml` `tests.yml` `types.yml` | Add `permissions: contents: read`, run on `staging` (PR + push) and `main` (push only) |
-| `.github/PULL_REQUEST_TEMPLATE.md` | Add "Changeset" checkbox + notice that the default target is `staging` |
-| `.changeset/config.json` | Keep `commit: false`, set `baseBranch: main`, consider `snapshot.useCalculatedVersion` for canary shape |
-| `packages/fp/package.json` | Fix `repository.url`, add `engines.node: ">=22.14.0"`, optionally `publishConfig.provenance: true` |
-| GitHub UI — branch protection | PR required on `main` and `staging`; linear history; no bypass list |
-| GitHub UI — rulesets | Enforce "PRs default to `staging`"; auto-close or redirect PRs targeting `main` |
-| GitHub UI — environments | Create `release` and `hotfix` environments with required reviewers; tag protection rules on `v*.*.*` |
-| npmjs.com UI | Register Trusted Publisher, switch Publishing access to `Require 2FA and disallow tokens`, revoke `NPM_TOKEN` |
-| `CONTRIBUTING.md` | Document the new flow, link to this plan, state the default PR target |
-| Secrets | Remove `NPM_TOKEN`. Add `NPM_READ_TOKEN` only if private dependencies are reintroduced |
+| Path | Action | Status |
+|------|--------|--------|
+| `.github/workflows/ci.yml` | Lint, typecheck, build, test, plus `changeset-check` on PRs targeting `staging`. | Active |
+| `.github/workflows/publish.yml` | Six-job release: detect, bump, push-bump, validate, publish, release. Trigger: `pull_request.closed` (merged) against `main`. | Active |
+| `.github/workflows/changesets-version.yml` | Opens/updates the Version Packages PR against `main` on every push to `staging`. Does not publish. | Active |
+| `.github/workflows/backmerge.yml` | Auto-opens a backmerge PR from `main` to `staging` after every push to `main`. Anti-recursion via branch-scope trigger, label check, and SHA-keyed concurrency. | Active |
 
+Future channels (documented in § 8, not yet implemented):
+
+- `canary.yml` — per-PR snapshots on the `canary` dist-tag (see § 8.1).
+- `prerelease-cycles.yml` — `next` / `beta` / `rc` phases (see § 8.2).
 ## Appendix B — References
 
 - Changesets — [Automating Changesets](https://github.com/changesets/changesets/blob/main/docs/automating-changesets.md)

--- a/docs/engineering/plans/release-pipeline.md
+++ b/docs/engineering/plans/release-pipeline.md
@@ -69,19 +69,30 @@
                     │
                     ▼
    ┌──────────────────────────────────────────┐
-   │  publish.yml runs on main:               │
-   │   - checkout main (fetch-depth 0)        │
-   │   - id-token: write (OIDC)               │
-   │   - environment: release                 │
-   │   - actions pinned by SHA                │
-   │   - upgrade npm to ≥ 11.5.1              │
-   │   - guard: version not yet on npm        │
-   │   - pnpm install --frozen-lockfile       │
-   │   - pnpm build                           │
-   │   - pnpm test                            │
-   │   - pnpm changeset publish --tag latest  │
-   │   - create git tag vX.Y.Z                │
-   │   - create GitHub Release                │
+   │  publish.yml runs on main as six jobs    │
+   │  in a chain: detect → bump → push-bump  │
+   │  → validate → publish → release          │
+   │                                          │
+   │   - detect: runs `pnpm changeset        │
+   │     status`; emits has_changesets        │
+   │   - bump: runs `pnpm changeset version`  │
+   │     on main locally                      │
+   │   - push-bump: rebase onto origin/main,  │
+   │     then push back (closes the #384      │
+   │     non-fast-forward race)               │
+   │   - validate: in `release` environment,  │
+   │     anti-republish guard, pnpm build,    │
+   │     pnpm test, smoke test on dist/       │
+   │   - publish: `pnpm changeset publish     │
+   │     --tag latest` via OIDC               │
+   │   - release: git tag vX.Y.Z and          │
+   │     GitHub Release with auto notes       │
+   │                                          │
+   │  Concurrency group: per-PR, not per-ref,  │
+   │  so a hotfix landing during a regular    │
+   │  release is not serialized. The anti-    │
+   │  republish guard in `validate` is the    │
+   │  safety net for the race.                │
    └────────────────┬─────────────────────────┘
                     ▼
       Provenance attestation generated automatically

--- a/docs/engineering/process/changesets.md
+++ b/docs/engineering/process/changesets.md
@@ -1,0 +1,549 @@
+# Changesets Process
+
+**Status:** Active
+**Owner:** Engineering
+**Last updated:** 2026-08-04
+**Applies to:** `@deessejs/fp` and any future workspace package in this monorepo
+
+This document describes how we use [Changesets](https://github.com/changesets/changesets) day
+to day to accumulate changes across branches and produce releases. It complements the
+[`docs/engineering/plans/release-pipeline.md`](../plans/release-pipeline.md) senior plan,
+which describes the *target* architecture. This page is the *current* practice.
+
+---
+
+## Goal: human-gated at merge, fully automated afterwards
+
+The release process for `@deessejs/fp` is designed to be **fully automated from the
+moment a pull request is merged into `main`**. Once a maintainer clicks "merge", no
+further human action is required for the change to reach npm users.
+
+Specifically, the chain that runs without any human intervention is:
+
+1. `changesets/action` opens or updates the "Version Packages" pull request against
+   `main`.
+2. The Version Packages PR is reviewed and merged.
+3. `publish.yml` runs on the merge commit:
+   - detects changesets,
+   - bumps versions,
+   - builds the package,
+   - runs the test suite,
+   - smoke-tests the built artifact,
+   - publishes to npm under the `latest` dist-tag via Trusted Publishing (OIDC),
+   - creates the `vX.Y.Z` git tag,
+   - creates the GitHub Release page.
+4. The auto-backmerge workflow propagates `main` to `staging` (and any active
+   `feature/*` branches rebase from `staging`).
+
+The only human-gated steps are:
+
+- The author opens a pull request with a Changeset file (§ 7).
+- A reviewer approves the pull request.
+- A reviewer approves the Version Packages PR.
+- A reviewer merges the Version Packages PR.
+
+Everything between "merge to `main`" and "user installs the new version from npm" is
+mechanical. There is no manual `pnpm version`, no manual `pnpm changeset publish`,
+no manual tag push, no manual GitHub Release. The pipeline is the maintainer's
+guarantee that every merged change ships.
+
+This is a deliberate trade-off: speed and consistency over discretionary review. If a
+change should not ship (broken code, security incident, partial feature), the place
+to stop it is *before* the merge, not after. Once a PR is on `main`, the release is
+imminent.
+
+---
+
+## 1. Why we accumulate changesets
+
+A Changeset is a small Markdown file under `.changeset/`. The file declares *which package*
+is affected, the *semver level* (`major` / `minor` / `patch`), and a one-line summary. The
+filename is a slug (e.g. `cyan-panda-dance.md`); the contents matter, the name does not.
+
+The reason this workflow exists at all is that it makes concurrent feature work *mergeable
+without conflict*. The classic case is two features that would otherwise both edit
+`packages/fp/package.json#version`:
+
+- `branch-a` and `branch-b` each add a Changeset file:
+  - `branch-a` adds `.changeset/cyan-panda-dance.md`.
+  - `branch-b` adds `.changeset/heavy-lion-sing.md`.
+- The Changeset files do not overlap. Merging both branches is a clean fast-forward.
+- At release time, the tool reads *every* Changeset in `.changeset/`, computes the next
+  semver, edits `package.json`, regenerates `CHANGELOG.md`, and deletes the consumed
+  Changeset files.
+
+This avoids the version-edit conflict entirely. The trade-off is that the actual version
+number is decided *at release time*, not at PR-merge time. The author decides the *impact
+level* of their change at code time; the tool rolls them up later.
+
+---
+
+## 2. The branch flow
+
+We follow the branching model in [`CLAUDE.md`](../../../CLAUDE.md):
+
+```text
+main  <-  staging  <-  dev
+```
+
+| Branch | Role | Receives PRs from | Changesets on this branch |
+| --- | --- | --- | --- |
+| `dev` | Day-to-day work | `feature/*`, `fix/*` | Yes, added by authors |
+| `staging` | Integration / release train | `dev`, `feature/*`, `fix/*` | Yes, accumulated from merged branches |
+| `main` | Releases only | Version Packages PR (auto), hotfix PRs | No, consumed by `pnpm changeset version` |
+
+A typical release cycle follows this path:
+
+1. **Feature work happens on `dev` (or short-lived `feature/*` branches).**
+   Each PR adds a Changeset file under `.changeset/`. The author picks the semver level
+   that matches the impact of their change:
+   - `patch` — bug fix, internal refactor, CI/doc change.
+   - `minor` — backwards-compatible API addition.
+   - `major` — breaking change to the public API. Rare; must be called out in the PR
+     description.
+
+2. **Feature branches are merged into `staging`.**  
+   Multiple Changeset files accumulate. They never conflict, because each one is a
+   distinct file.
+
+3. **A release engineer opens (or updates) the Version Packages PR.**  
+   In the current pipeline this is automated by `changesets/action@v2` on push to
+   `staging`. The PR runs `pnpm changeset version`, which:
+   - reads every Changeset in `.changeset/`,
+   - computes the next semver from the highest-impact level present,
+   - rewrites `packages/fp/package.json#version`,
+   - regenerates `packages/fp/CHANGELOG.md`,
+   - **deletes the consumed Changeset files**.
+
+4. **The Version Packages PR is reviewed and merged into `main`.**  
+   This is the only path that lands a new version on `main`. It is a regular PR; no
+   special permission is required to merge it.
+
+5. **The release workflow on `main` runs.**  
+   Build, test, smoke-test, `pnpm changeset publish --tag latest`, tag, GitHub Release.
+   The `main` commit no longer contains Changeset files — they were deleted in step 3.
+
+---
+
+## 3. The double-merge trap
+
+The most common operational mistake with this flow is the **double-merge**. It is worth
+calling out explicitly because it is silent: nothing fails, but the next release ends up
+with an unexpected version bump.
+
+The trap:
+
+1. PR-A (with `.changeset/cyan-panda-dance.md`) is merged into `staging`.
+2. PR-B (with `.changeset/heavy-lion-sing.md`) is merged into `staging`.
+3. `changesets/action` opens a Version Packages PR. Both Changesets are still on
+   `staging` at this point.
+4. The Version Packages PR is merged into `main`. `pnpm changeset version` runs as part
+   of the merge, consuming both Changesets. `main` now has version `1.1.1` and **no
+   Changeset files**.
+5. The release workflow publishes `1.1.1`. Done.
+6. *Without the back-merge*: `staging` still has both Changeset files. If a maintainer
+   opens another Version Packages PR from `staging` (or if `changesets/action` does),
+   it will run `pnpm changeset version` *again* and produce `1.1.2` with the *same*
+   release notes, because the Changeset files were never removed from `staging`.
+
+The fix is mechanical: after a Version Packages PR is merged into `main`, back-merge
+`main` into `staging` (and into `dev` if `dev` is long-lived). This is normally done
+automatically by the release workflow, but it must be done — and it must be done *after*
+the version bump lands on `main`, not before.
+
+The same rule applies, with reversed direction, after a hotfix lands on `main`: back-merge
+`main` into `staging` and `dev` so the hotfix version is reflected in the integration
+branch.
+
+---
+
+## 4. Authoring a Changeset
+
+This section is the writing guide. It complements the per-PR requirement described in
+§ 7 — that section says *every PR must have a Changeset*; this one says *how to write a
+good one*.
+
+### 4.1 The shape
+
+A Changeset is a single Markdown file under `.changeset/`. Its filename is a slug
+(Changesets generates one when you run `pnpm changeset`); the contents matter, the
+filename does not. The contents follow this shape:
+
+```md
+---
+"@deessejs/fp": minor
+---
+
+Add the `Result.tryCatch` and `Maybe.tryMaybe` families.
+```
+
+The first `---` block is YAML frontmatter: a mapping from package name to semver level.
+The body is the summary that will land in `CHANGELOG.md` and the GitHub Release notes.
+There is no required header inside the body; a single paragraph is the typical shape, but
+multi-line Markdown (code blocks, lists, links) is fine if the change warrants it.
+
+### 4.2 Choosing the semver level
+
+The semver level encodes the **impact on the consumer of the package**, not the size of
+the diff. A 200-line internal refactor is `patch`; a one-line rename of a public symbol
+is `major`. The decision tree:
+
+- **`major`** — anything that *requires* a consumer to change their code to keep working.
+  A symbol renamed or removed. A signature change. A behaviour change that flips a
+  default. If you can answer "yes, a user has to edit their code" with confidence, it is
+  `major`. Major bumps are rare and must be called out in the PR description.
+- **`minor`** — anything that *adds* a new capability without breaking existing code.
+  A new exported function. A new method on `Ok` / `Err` / `Some` / `None`. A new option
+  on an existing function. If the change is purely additive, it is `minor`.
+- **`patch`** — anything that *fixes* a bug, *improves* an internal detail, or *changes
+  documentation*. A wrong type narrowing. A clearer error message. A perf tweak. A CI
+  change. A typo in a docstring.
+
+Cases that come up often and are easy to misclassify:
+
+- **Refactor that exposes a new public export**: usually `minor`, because the export is a
+  new capability, even if the refactor itself was internal.
+- **Bug fix that happens to change a default value**: usually `major`, because consumers
+  that depended on the old default will break.
+- **Deprecating a symbol without removing it**: `minor` with a clear note in the summary;
+  removal of the same symbol later is `major`.
+- **Performance improvement with no API change**: `patch`. Consumers do not need to
+  change anything.
+- **Type-only change that narrows or widens a return type**: if a consumer's code stops
+  compiling, it is `major`; if it now compiles *better* (more precise inference), it is
+  `minor` or `patch` depending on whether the change is additive or corrective.
+
+When in doubt, default to `minor` and call it out in the PR description. It is cheaper
+to ship a `minor` that turns out to be a `patch` than a `patch` that turns out to be a
+`major`.
+
+### 4.3 Writing a good summary
+
+The summary line is what shows up in `CHANGELOG.md` and the GitHub Release. It is
+written for the **user upgrading the package**, not the maintainer reviewing the PR. A
+good summary tells the reader, in one sentence, what they get or what they have to watch
+out for.
+
+Conventions in the wider Changesets ecosystem, which we follow:
+
+- **Past tense for completed changes**: "Added `Result.tryCatch`", "Fixed incorrect
+  narrowing in `Maybe.map`". The release has already happened by the time the user reads
+  the changelog.
+- **Lead with the user-visible effect, not the implementation**: not "Extracted a helper
+  for fold", but "Simplified error handling for nested `Result` chains".
+- **Name the symbols involved**: users grep their changelog for the API they care about.
+  "Add `Result.tryCatch`" is searchable; "Improve error handling" is not.
+- **One logical change per file**: if a PR introduces two unrelated changes that warrant
+  different semver levels, write two Changeset files. A single Changeset file can have
+  multiple lines, but it should be one coherent change.
+
+| Good | Bad | Why |
+| --- | --- | --- |
+| `Added Result.tryCatch that wraps a throwing function into a Result.` | `Add stuff` | The first names the symbol and the effect; the second is unsearchable. |
+| `Fixed incorrect narrowing when match returns a Result on the err branch.` | `Fix bug` | The first is searchable and tells the user what was wrong; the second is noise. |
+| `Renamed Maybe.fromNullable to maybe for consistency with Result constructors.` | `Update API` | The first tells the user which symbol moved; the second is a heading, not a sentence. |
+| `Deprecated errOr; it will be removed in 2.0. Use err instead.` | `Deprecate` | The first tells the user what to do; the second is a label. |
+| `Bumped minimum Node version to 22.14 to match the engines field.` | `Node bump` | The first explains the impact; the second is shorthand for maintainers. |
+
+If a change needs more than a sentence to explain, multi-line Markdown is fine. Common
+patterns:
+
+- A short paragraph followed by a code block showing the new API.
+- A short paragraph followed by a list of related changes.
+- A short paragraph that references a longer doc page (e.g. the wiki or `apps/web`).
+
+### 4.4 Multi-package changesets
+
+When a single PR affects more than one package in the monorepo, list all affected
+packages in the same frontmatter, each with its own semver level. The tool rolls them up
+independently at release time.
+
+```md
+---
+"@deessejs/fp": minor
+"@deessejs/errors": patch
+---
+
+Add `Result.tryCatch` that returns typed errors from `@deessejs/errors` shapes.
+```
+
+A few rules:
+
+- Each package gets the semver level that matches *its* impact, not the highest level
+  across the PR. If `@deessejs/fp` adds a function but `@deessejs/errors` only adjusts an
+  internal helper, the levels differ.
+- If the changes in two packages are *unrelated* (different PRs accidentally bundled), do
+  not bundle them. Split into two Changeset files.
+- The summary should describe the user-facing effect of the bundle. If the changes are
+  conceptually one feature, one summary is fine. If they are two features that happen
+  to share a PR, prefer two Changeset files.
+
+### 4.5 When a Changeset is empty
+
+For changes that have **no user-visible effect at all** — a pure internal refactor, a
+CI workflow change, a dependency bump with no behaviour change, a docstring typo — the
+body of the Changeset is intentionally short and the semver level is `patch`. The
+Changesets CLI ships an `--empty` flag for this case:
+
+```bash
+pnpm changeset --empty -- --patch
+```
+
+This produces a Changeset file with the right frontmatter and an empty body. The audit
+trail is preserved (the file exists, the level is recorded), but the CHANGELOG entry
+is a one-liner with no body. This is preferred over skipping the Changeset file
+entirely, because the per-PR rule (see § 7) requires a Changeset for every PR and the
+release tooling will trip on a missing file regardless of whether the change is
+user-visible.
+
+`--empty` is **not** an exemption. It is a *form* of Changeset, with the body left
+intentionally empty because the changelog does not need to know.
+
+### 4.6 Anti-patterns
+
+What *not* to put in a Changeset. The list is short because most of these are caught by
+the § 4.3 *good vs bad* table above, but they recur often enough to be worth calling
+out explicitly.
+
+- **Implementation chatter.** "Extracted the `fold` helper into its own module",
+  "Refactored the type definitions to use a conditional type", "Added a private
+  utility". The user does not care how you wrote it; they care what they get.
+- **Internal cross-references.** "See PR #388", "Linked to the design doc in
+  `docs/internal/`", "Companion to the changes in `packages/internal`". These rot as
+  soon as the PR is renumbered or the doc moves.
+- **Marketing.** "We're excited to announce", "This release brings powerful new
+  capabilities". Releases are not press releases.
+- **Multi-line apology.** "Sorry for the previous breaking change, this reverts..." is
+  fine *once*; repeated in every release it becomes noise. State the change, not the
+  history.
+- **Bullet-point changelog when one sentence suffices.** A one-line summary that says
+  "Fixed narrowing in `Maybe.flatMap`" is better than three bullets about the same
+  fix. Reserve bullets for genuinely independent changes.
+- **Empty body without `--empty`.** A Changeset file with frontmatter and no body looks
+  like an authoring mistake. Use `pnpm changeset --empty` so the intent is explicit and
+  the CLI does not prompt for a body.
+
+### 4.7 A worked example
+
+A PR adds a new `Result.tryCatch` and fixes a typing bug in `Maybe.flatMap`. Two
+unrelated changes, two Changeset files:
+
+```text
+.changeset/cool-otters-dance.md
+---
+"@deessejs/fp": minor
+---
+
+Added `Result.tryCatch` that wraps a throwing function into a `Result<T, unknown>`,
+narrowing to typed errors via the optional second argument.
+```
+
+```text
+.changeset/heavy-lion-sing.md
+---
+"@deessejs/fp": patch
+---
+
+Fixed `Maybe.flatMap` losing the narrowed type when the callback returns `None`.
+```
+
+Note the two different semver levels, the two user-facing summaries, and the named
+symbols. Both files exist; both will be consumed at the next `pnpm changeset version`.
+
+---
+
+## 5. Inspecting what will happen
+
+Two commands are useful when reviewing a Version Packages PR or a release plan:
+
+```bash
+# Are there pending changesets? What would the next version be?
+pnpm changeset status
+
+# What would the next CHANGELOG.md entry look like, in detail?
+pnpm changeset version --snapshot
+```
+
+`pnpm changeset status` is the supported, accurate way to answer "is there a release to
+cut?" and is the recommended replacement for the `git diff` heuristic that some older
+pipelines use.
+
+`pnpm changeset version --snapshot` is non-destructive: it produces the bumped versions
+and the regenerated changelog in a temp directory (printed to stdout) without writing
+back to the working tree. It is safe to run locally for review.
+
+---
+
+## 6. The full picture
+
+```text
+dev / feature/*                    staging                              main
+─────────────                      ────────                             ────
+add .changeset/a.md ─┐
+                     │
+                     │  PR merge
+                     ▼
+                     │  accumulate     changesets/action runs           │
+                     │  ─────────►     opens Version Packages PR        │
+                     │                 on staging → main                │
+                     │                                                 │
+                     │                                                 │  PR merge
+                     │                                                 ▼
+                     │                                                 │  pnpm changeset version
+                     │                                                 │  (bump + changelog +
+                     │                                                 │   delete consumed
+                     │                                                 │   changesets)
+                     │                                                 │
+                     │                                                 │  release workflow
+                     │                                                 │  ────────────────►
+                     │                                                 │  build → test →
+                     │                                                 │  smoke → publish →
+                     │                                                 │  tag → GitHub Release
+                     │
+                     │  back-merge from main
+                     ▼
+                  staging is now in sync with main: same version,
+                  no leftover changesets, no surprise 1.1.2.
+```
+
+The single rule that holds this together: **after every merge into `main`, back-merge
+`main` into `staging`**. Everything else in the diagram is mechanical.
+
+### 6.5 Every merge to `main` is a release
+
+This is the consequence that makes the workflow worth running: **once a pull request
+lands on `main`, its content is published to npm**. There is no "merge now, release
+later" mode, no "merge without publishing" mode, no way to land code on `main` without
+producing a new version of `@deessejs/fp` under the `latest` dist-tag.
+
+This is not a separate rule added on top of the workflow — it is a *consequence* of two
+rules that already hold:
+
+1. **Every PR adds a Changeset** (§ 7). The CI refuses to merge any PR that does not.
+2. **The release workflow runs on every push to `main`** (the `publish.yml` workflow
+   fires on `push` events to the default branch, after the Version Packages PR merges).
+
+Put together: every merge to `main` carries at least one Changeset, and the workflow
+publishes it. The release is therefore not a *decision* the maintainer makes; it is a
+*mechanical effect* of a successful merge.
+
+Two practical consequences follow:
+
+- **There is no "batch PR" that lands several changes without triggering multiple
+  releases.** Each merge produces one version, each Changeset in it produces one
+  changelog entry. A maintainer who wants to ship five changes in one release must put
+  them in the same PR (or in PRs merged between two consecutive `pnpm changeset
+  version` runs — but that window is empty in this project, since `version` runs as
+  part of the merge).
+- **A PR that is purely documentation-only still produces a release.** The per-PR
+  Changeset rule has no exemption for non-code changes (§ 7.3), so a PR that only
+  touches `docs/` or `apps/web/` carries a `patch` Changeset (often empty via
+  `pnpm changeset --empty`). The merge still produces a version bump on npm. This is
+  the price of the rule and it is intentional — the audit trail is the point.
+
+This is why the back-merge rule (§ 3, § 6) matters: every release is final, and the
+single source of truth is `main`. `staging` must reflect `main` after every release,
+otherwise a future Version Packages PR will replay Changesets that have already shipped.
+
+---
+
+## 7. Per-PR Changeset rule
+
+**Every pull request must add a Changeset file under `.changeset/`.** This is not a
+convention we encourage; it is a hard requirement enforced by CI. The rationale is that
+the accumulation workflow described above only works if every change ships with a
+Changeset — if any PR slips through without one, that change is *invisible* to the
+release tooling and either ships silently or requires a hotfix to recover.
+
+### 7.1 The rule
+
+- A PR is compliant when its diff contains at least one file matching
+  `^.changeset/.*\.md$`, excluding the `README.md` of the changesets folder itself.
+- The rule applies to **every** PR that targets `staging`, regardless of the kind of
+  change: feature, fix, refactor, CI change, docs change, dependency bump, anything.
+- There are **no exemptions by category** — not for refactors, not for CI, not for
+  docs. A PR that is "just a typo" still adds a Changeset (typically `patch` and a
+  one-line summary).
+- The only carve-out is technical: a Changeset is *required*, but its *content* may
+  legitimately be empty. For changes with no user-visible effect, run
+  `pnpm changeset --empty` to produce a Changeset file that records the no-op
+  semver level. This keeps the audit trail intact without inflating the changelog.
+- **Hotfix exemption.** A hotfix PR that targets `main` directly (see `hotfix.md` § 4)
+  does **not** carry a Changeset on the merge commit. The per-PR rule's scope is
+  `staging`, not `main`. The `changeset-check` CI job (§ 7.2 below) is gated on
+  `pull_request.base.ref == 'staging'` and skips hotfix PRs. The audit entry for the
+  hotfix is added afterwards via a follow-up PR on `staging` that follows the per-PR
+  rule (see `hotfix.md` § 7), and the changelog entry appears in the next regular
+  release. The hotfix exemption is the only carve-out, and it is *only* for hotfix PRs
+  targeting `main`.
+
+### 7.2 How it is enforced
+
+The rule is enforced by a dedicated CI job, not by reviewer vigilance. The job runs on
+every PR targeting `staging`:
+
+- **Job name:** `changeset-check`.
+- **Trigger:** any push to a PR whose base is `staging`.
+- **Logic:** diff the PR head against the merge base on `staging`, list the files
+  added, and assert that at least one matches `^.changeset/.*\.md$` (excluding
+  `README.md`).
+- **Result:** the job fails with a clear message linking to this section if no
+  Changeset is present. The merge button stays disabled until the author adds one.
+- **Status check:** `changeset-check` is a **required status check** on the
+  `staging` branch protection ruleset, so a green run is a hard prerequisite for
+  merge. There is no bypass — not for maintainers, not for hotfixes.
+
+In other words, the mechanism is *blocking* by design. The Changesets GitHub Bot
+(installed in non-blocking mode) provides a soft nudge on top: it comments on PRs
+that lack a Changeset, but it is the CI status check that actually prevents the
+merge.
+
+### 7.3 Why no exemptions
+
+A common objection is "this is just a refactor, it doesn't need a Changeset." The
+counter-argument is operational, not semantic:
+
+- **A refactor that ships in the same release as a feature will appear in the
+  changelog anyway** — once the tool rolls up the changesets, the refactor is in
+  the same version as the feature. Skipping the Changeset for the refactor does not
+  hide it; it just removes the audit trail.
+- **A refactor can break a downstream user in subtle ways.** A Changeset with
+  `patch` and a one-line summary is the cheapest possible insurance against the
+  "I didn't know this changed" report.
+- **CI-only or docs-only changes are not exempt either**, because the *release
+  tooling* doesn't know which is which. A blanket rule is enforceable; a
+  category-aware rule is not.
+
+The cost of a per-PR Changeset is roughly 30 seconds of author time. The cost of a
+missing Changeset is, in the worst case, a silent regression in a published version.
+The trade-off is unambiguous.
+
+### 7.4 Author checklist
+
+Before opening a PR, an author should have:
+
+1. A local branch with the code change.
+2. A new file under `.changeset/` whose frontmatter lists the affected packages
+   and the semver level, and whose body is a user-facing one-line summary.
+3. For pure refactors or no-user-impact changes, `pnpm changeset --empty` instead
+   of a hand-written file.
+
+When the PR is opened, the author should see the `changeset-check` job turn green
+within a minute. If it turns red, the diff is missing a Changeset file — adding one
+will turn it green on the next push.
+
+---
+
+## 8. Related documents
+
+- [`docs/engineering/plans/release-pipeline.md`](../plans/release-pipeline.md) — the
+  target architecture, including the Trusted Publishing setup and the `release`
+  environment protections.
+- [`docs/engineering/plans/release-pipeline-github-ui-setup.md`](../plans/release-pipeline-github-ui-setup.md)
+  — the one-time GitHub-side configuration (Trusted Publisher, environment reviewers).
+- [`hotfix.md`](hotfix.md) — the urgent-fix path. Operationally a PR against `main`
+  directly; uses the same `publish.yml` workflow as a regular release.
+- [`canary.md`](canary.md) — the pre-release snapshot path. Future feature, not
+  currently implemented. Documented for completeness so the design is not lost.
+- The published process page in the wiki, *Release Process*, which mirrors this document
+  for an external audience.

--- a/docs/engineering/process/changesets.md
+++ b/docs/engineering/process/changesets.md
@@ -473,7 +473,7 @@ release tooling and either ships silently or requires a hotfix to recover.
   `staging`, not `main`. The `changeset-check` CI job (§ 7.2 below) is gated on
   `pull_request.base.ref == 'staging'` and skips hotfix PRs. The audit entry for the
   hotfix is added afterwards via a follow-up PR on `staging` that follows the per-PR
-  rule (see `hotfix.md` § 7), and the changelog entry appears in the next regular
+  rule (see `hotfix.md` § 8), and the changelog entry appears in the next regular
   release. The hotfix exemption is the only carve-out, and it is *only* for hotfix PRs
   targeting `main`.
 

--- a/docs/engineering/process/changesets.md
+++ b/docs/engineering/process/changesets.md
@@ -483,7 +483,8 @@ The rule is enforced by a dedicated CI job, not by reviewer vigilance. The job r
 every PR targeting `staging`:
 
 - **Job name:** `changeset-check`.
-- **Trigger:** any push to a PR whose base is `staging`.
+- **Trigger:** any pull request event targeting `staging` (opened, synchronize, reopened).
+- **Exclusions:** PRs carrying the `bot:backmerge` label are skipped. The `backmerge.yml` workflow labels its PRs this way so the auto-backmerge from `main` does not require a Changeset file.
 - **Logic:** diff the PR head against the merge base on `staging`, list the files
   added, and assert that at least one matches `^.changeset/.*\.md$` (excluding
   `README.md`).

--- a/docs/engineering/process/changesets.md
+++ b/docs/engineering/process/changesets.md
@@ -23,7 +23,7 @@ Specifically, the chain that runs without any human intervention is:
 1. `changesets/action` opens or updates the "Version Packages" pull request against
    `main`.
 2. The Version Packages PR is reviewed and merged.
-3. `publish.yml` runs on the merge commit:
+3. `publish.yml` runs on the pull_request closed (merged) event:
    - detects changesets,
    - bumps versions,
    - builds the package,
@@ -420,8 +420,8 @@ This is not a separate rule added on top of the workflow — it is a *consequenc
 rules that already hold:
 
 1. **Every PR adds a Changeset** (§ 7). The CI refuses to merge any PR that does not.
-2. **The release workflow runs on every push to `main`** (the `publish.yml` workflow
-   fires on `push` events to the default branch, after the Version Packages PR merges).
+2. **The release workflow runs on every merge to `main`** (the `publish.yml` workflow
+   fires on `pull_request.closed` events against `main`, gated on `merged == true`).
 
 Put together: every merge to `main` carries at least one Changeset, and the workflow
 publishes it. The release is therefore not a *decision* the maintainer makes; it is a

--- a/packages/fp/CHANGELOG.md
+++ b/packages/fp/CHANGELOG.md
@@ -6,7 +6,7 @@
 > `.changeset/release-1.1.1.md`) but never consumed via
 > `pnpm changeset version`. The pipeline branch this note lives in
 > does not regenerate the CHANGELOG; the next release will produce
-> a 1.1.1 (or 1.2.0) entry automatically.
+> a 1.1.2 (or 1.2.0) entry that implicitly covers the 1.1.1 work.
 
 ## 1.1.0
 

--- a/packages/fp/CHANGELOG.md
+++ b/packages/fp/CHANGELOG.md
@@ -1,5 +1,13 @@
 # @deessejs/fp
 
+> **Note (2026-08-06).** `package.json#version` is at 1.1.1, but
+> `CHANGELOG.md` tops out at 1.1.0. This is a known pre-branch
+> inconsistency: the 1.1.1 release was prepared (see
+> `.changeset/release-1.1.1.md`) but never consumed via
+> `pnpm changeset version`. The pipeline branch this note lives in
+> does not regenerate the CHANGELOG; the next release will produce
+> a 1.1.1 (or 1.2.0) entry automatically.
+
 ## 1.1.0
 
 ### Minor Changes


### PR DESCRIPTION
## What this PR permits

This PR activates the release pipeline described in the wiki Release-Process page. After this lands, the maintainer can:

- Cut a release by merging a PR to main. The PR merge is the release trigger.
- Trust the per-PR Changeset rule (after enabling the required-status-check on staging, see Action required).
- Ship a hotfix without waiting for a regular release in flight (per-PR concurrency).
- Get a Version Packages PR automatically (changesets-version.yml on every push to staging).
- Have staging catch up automatically (backmerge.yml on every push to main).
- Recover cleanly from a missed version bump (rebase in push-bump).

## What this PR does

### Pipeline changes (commits 1-9, the four open issues)

1. docs(process): explicit hotfix exemption in changesets.md 7.1
2. docs(fp): note 1.1.1 / CHANGELOG inconsistency
3. ci(ci): add changeset-check job
4. ci(workflows): add changesets-version.yml
5. ci(workflows): add backmerge.yml
6. ci(publish): split into six jobs, add rebase, use pnpm changeset status, fix concurrency
7. docs(release): sync release-pipeline plan with the six-job pipeline
8. ci(workflows): use major-version tags instead of SHA pins
9. ci(ci): exclude bot:backmerge PRs from changeset-check

### Post-review fixes (commits 10-18, critical bugs + security + docs)

10. fix(publish): invert changeset status exit-code logic in detect
11. fix(changesets-version): open Version Packages PR against main
12. fix(backmerge): escalate open-backmerge job to write permissions
13. docs(changesets): correct cross-reference to hotfix.md section 7 to 8
14. docs(fp): correct CHANGELOG note version arithmetic (1.1.2, not 1.1.1)
15. docs(changesets): correct publish.yml trigger description (pull_request.closed, not push)
16. docs(changesets): document bot:backmerge exclusion in changeset-check
17. docs(release): refresh release-pipeline.md to match actual six-job pipeline
18. docs(github-ui-setup): drop never-landed entrypoint/reusable-workflow pattern

### Post-polish (commit 19)

19. ci(publish): post-review polish
    - collapse bump + push-bump into one job (5-job chain instead of 6)
    - remove environment: release from validate (publish env gates publish only)
    - add tag-already-exists guard before git tag in release job
    - harden changeset-check with a merge-base sanity check and an explicit base-ref fetch (replaces the depth=0 heuristic)

After commit 19, the chain is detect -> push-bump -> validate -> publish -> release (5 jobs).

## Mapping to the four open issues

| Issue | Resolution |
| --- | --- |
| #383 (split release job) | Commit 6: six jobs. Commit 19 further collapses to five. |
| #384 (rebase bump onto origin/main) | Commit 6: push-bump runs git fetch origin main + git rebase origin/main before git push. |
| #385 (replace git diff with pnpm changeset status) | Commit 6: detect runs pnpm changeset status, inverts exit code. |
| #389 (enforce per-PR Changeset rule via CI) | Commit 3: changeset-check job in ci.yml. Required-status-check wiring is a GitHub-side follow-up. |

## Action required (post-merge)

- Add changeset-check as a required status check on the staging branch protection ruleset. This is a GitHub Settings change, not a workflow file change.
- Dependabot will track the new major-version tags. Configure a .github/dependabot.yml github-actions entry if you want automated PRs.

## Verification

- git log --oneline origin/main..HEAD shows the nineteen commits.
- pnpm changeset status exits 0 in a clean tree, 1 after pnpm changeset.
- Test PR with a patch Changeset against staging -> changeset-check passes. Merge -> changesets-version.yml opens a Version Packages PR against main. Merge that PR into main -> publish.yml runs as five jobs, publishes to npm via Trusted Publishing.
- Test PR targeting main (hotfix) -> changeset-check skips. After merge, backmerge.yml opens a backmerge PR to staging.

## Risks

- Two PRs merging into main within seconds run publish.yml in parallel under per-PR concurrency. The anti-republish guard in validate catches the race.
- Conflicts in packages/fp/package.json#version or CHANGELOG.md between two concurrent PRs fail at push-bump rebase step. Manual recovery required.
- Major-version tags can move under you. Dependabot will surface relevant updates (consider a 7-day cooldown to avoid auto-adoption during upstream incidents, per the March 2026 Trivy supply-chain compromise post-mortem).
- The branch carries the previously-untracked docs/engineering/process/changesets.md.

## Outstanding senior concerns (post-branch follow-up)

Two senior concerns surfaced during research that are out of scope for this branch but worth flagging:

- SHA pinning vs major-version tags: the incident post-mortem for the March 2026 Aqua Security / trivy-action compromise recommends SHA pinning to full commit hashes. Commit 8 on this branch chose major-version tags for legibility. A follow-up branch could restore SHA pinning if the threat model warrants. The current Dependabot config does not include a github-actions entry yet.
- peter-evans/create-pull-request in backmerge.yml: post-mortems recommend replacing this with the native gh CLI (gh pr create) for a smaller attack surface. The article A complete guide to hardening GitHub Actions points at this specifically.

## Subagent review dimensions

Three subagents reviewed this branch in parallel: correctness (workflows, YAML, GitHub Actions expression syntax, Changesets CLI exit-code semantics), security (permissions, OIDC trust boundary, anti-recursion), and documentation (cross-references, version arithmetic, stale sections, code/doc consistency).

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>