### PR TITLE
chore: dummy e2e test of the new release pipeline

### DIFF
--- a/.changeset/dummy-pipeline-test.md
+++ b/.changeset/dummy-pipeline-test.md
@@ -1,0 +1,8 @@
+---
+"@deessejs/fp": patch
+---
+
+Test of the new five-job release pipeline. This PR exists only to
+validate that changeset-check enforces the per-PR Changeset rule,
+that changesets-version.yml opens a Version Packages PR, and
+that the full chain runs end-to-end.


### PR DESCRIPTION
Dummy PR to validate the new pipeline end-to-end after the merge of #394.

## What this PR tests

- **changeset-check** is enforced as a required status check on staging — this PR should pass.
- **changesets-version.yml** opens or updates a Version Packages PR against `main` after this PR merges.
- The full chain (`detect → push-bump → validate → publish → release`) runs end-to-end after the Version Packages PR merges into `main`.
- **backmerge.yml** opens a backmerge PR from `main` → `staging` after the publish.

## Changeset

This is itself the changeset file. The body above is the audit-trail note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)