### PR TITLE
chore: e2e test of the new release pipeline (after staging back-merge)

### DIFF
--- a/.changeset/e2e-pipeline-test-2.md
+++ b/.changeset/e2e-pipeline-test-2.md
@@ -1,0 +1,6 @@
+---
+"@deessejs/fp": patch
+---
+
+End-to-end test of the new release pipeline on staging after the back-merge. This PR validates that changeset-check passes, that changesets-version.yml opens the Version Packages PR against main on merge, that publish.yml runs end-to-end, and that backmerge.yml keeps staging in sync.
+No functional change to the library.


### PR DESCRIPTION
Dummy PR to validate the new release pipeline end-to-end after the back-merge (PR #396) brought the new pipeline onto staging.

## What this PR tests

- **changeset-check** is enforced as a required status check on staging. This PR should pass.
- **changesets-version.yml** opens or updates a Version Packages PR against `main` after this PR merges.
- The full chain (`detect → push-bump → validate → publish → release`) on `main` runs end-to-end after the Version Packages PR merges into `main`.
- **backmerge.yml** on `main` opens a backmerge PR from `main` → `staging` after the publish completes.

## Changeset

This is the changeset file itself, with `patch` level. No functional change to the library.

🤖 Generated with [Claude Code](https://claude.com/claude-code)