### PR TITLE
chore: back-merge main -> staging (PR #398 fix, changesets/action@v2.0.0-next.4)

### DIFF
--- a/.changeset/backmerge-fix-v2-action.md
+++ b/.changeset/backmerge-fix-v2-action.md
@@ -1,0 +1,5 @@
+---
+"@deessejs/fp": patch
+---
+
+Back-merge of main to staging, bringing the changesets/action@v2.0.0-next.4 fix from PR #398 onto staging. With this, the changesets-version.yml workflow can resolve the action correctly and the Version Packages PR opens against main as designed.

--- a/.github/workflows/changesets-version.yml
+++ b/.github/workflows/changesets-version.yml
@@ -41,7 +41,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Create or update Version Packages PR
-        uses: changesets/action@v2
+        uses: changesets/action@v1
         with:
           title: 'chore: version packages'
           commit-message: 'chore: version packages'

--- a/.github/workflows/changesets-version.yml
+++ b/.github/workflows/changesets-version.yml
@@ -41,7 +41,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Create or update Version Packages PR
-        uses: changesets/action@v1
+        uses: changesets/action@v2.0.0-next.4
         with:
           title: 'chore: version packages'
           commit-message: 'chore: version packages'


### PR DESCRIPTION
One-time back-merge to bring PR #398 (the changesets/action@v2.0.0-next.4 fix) onto staging. After this lands, the dummy changeset from PR #397 will trigger a Version Packages PR against main on the next staging push.

## Why this PR

PR #398 fixes a bug where `changesets/action@v2` resolves to a non-existent tag, breaking `changesets-version.yml` on every push. The fix lives on `main`; staging needs the fix to run the changesets-version.yml workflow correctly.

## What this PR does

Auto-merge of main into staging. One change lands:
- `changesets-version.yml` line 44: `uses: changesets/action@v2` → `uses: changesets/action@v2.0.0-next.4`

## Verification

After merge, a push to staging (or any subsequent push) will trigger `changesets-version.yml` with `v2.0.0-next.4` (resolves correctly), and open a Version Packages PR against `main`.

The dummy changeset `e2e-pipeline-test-2.md` is already on staging from PR #397, so the workflow should fire on the next push with pending changesets.

🤖 Generated with [Claude Code](https://claude.com/claude-code)