### PR TITLE
fix(changesets): disable format to skip missing prettier

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "format": false,
   "ignore": []
 }


### PR DESCRIPTION
Fixes the changesets-version.yml workflow which fails after the v3 CLI upgrade because changesets v3 tries to format its output via the project's formatter and our repo doesn't have prettier installed.

## What this PR does

Adds `"format": false` to `.changeset/config.json`. This disables the auto-format step in `changeset version`.

## Why this is needed

After PR #400 (CLI v3 upgrade), `changeset version` runs but fails inside the format package:

```
Error: Process exited with non-zero status (254)
    at async packageManagerExecute (... @changesets/format/dist/index.js:26:9)
```

The format package reads `.prettierrc` and decides to run prettier via `pnpm prettier --write ...`. We have a `.prettierrc` (used by our existing `format` script via `pre-commit`), but `prettier` is not in `devDependencies`. The subprocess fails with a missing-binary error.

## Why not install prettier

- We don't need changesets to format its own output. The `package.json` files updated by changesets are auto-generated and consistent; prettier formatting is cosmetic.
- The existing `.prettierrc` is for our hand-written source code (TypeScript, Markdown). Changesets writes JSON files internally; prettier would help marginally there.
- Adding a devDep just for cosmetic formatting of changelog files is excess.

## Why not just remove .prettierrc

The `.prettierrc` is consumed by `pnpm format` and pre-commit hooks. Removing it would break those.

## Why not pin to a specific formatter

Pinning to (e.g.) `"format": "prettier"` would still try to run prettier. We don't have it. Same for `"format": "biome"`. The only fix that doesn't add a devDep is `"format": false`.

## Verification

After merge:
- Push to staging triggers `changesets-version.yml`.
- The action runs `changeset version` with format disabled.
- The Version Packages PR opens against `main` with the bumped version and changelog.
- No formatting subprocess is invoked.

🤖 Generated with [Claude Code](https://claude.com/claude-code)