### PR TITLE
chore: back-merge main -> staging (PR #402 format: false fix)

### DIFF
--- a/.changeset/backmerge-format-fix.md
+++ b/.changeset/backmerge-format-fix.md
@@ -1,0 +1,5 @@
+---
+"@deessejs/fp": patch
+---
+
+Back-merge of main to staging, bringing the format: false fix from PR #402. Without this, changesets v3 tries to invoke prettier (not in devDependencies) and the format step fails. With format: false, the Version Packages PR pipeline runs end-to-end.

--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,6 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
+  "format": false,
   "ignore": []
 }


### PR DESCRIPTION
One-time back-merge to bring PR #402 (the format: false fix) onto staging. After merge, changesets-version.yml should no longer fail at the format step.