### PR TITLE
fix(publish): detect empty changesets via JSON output instead of exit code

### DIFF
--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -40,6 +40,9 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      - name: Fetch origin/staging
+        run: git fetch origin staging:refs/remotes/origin/staging
+
       - name: Check if backmerge is needed
         id: check
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,18 +65,21 @@ jobs:
       - name: Run pnpm changeset status
         id: status
         run: |
-          # `pnpm changeset status` exits 0 on the happy path: when
-          # changesets ARE pending (it successfully reports their
-          # status). It exits non-zero only when packages changed but
-          # no changeset is present, which is a config error. We
-          # invert the exit code: 0 means "proceed".
-          if pnpm changeset status; then
+          # `pnpm changeset status` exits 0 in two cases:
+          # (a) pending changesets exist, or (b) nothing to do.
+          # Exit 1 only on a config error. Since exit code alone is
+          # ambiguous, we use --output to dump the release plan and
+          # count releases in the changesets array.
+          pnpm changeset status --output status.json >/dev/null
+          RELEASES=$(node -e "const p=require('./status.json'); console.log((p.changesets||[]).reduce((n,c)=>n+(c.releases||[]).length,0))")
+          if [ "$RELEASES" -gt 0 ]; then
             echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "Pending changesets found — proceeding with release."
+            echo "Pending changesets found ($RELEASES releases) — proceeding with release."
           else
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
             echo "No pending changesets — skipping release."
           fi
+          rm -f status.json
 
   push-bump:
     name: Bump and push version to main


### PR DESCRIPTION
Fixes two issues found after PR #404 merge:

1. **`publish.yml` `detect` job** falsely reported pending changesets on the merge commit of a Version Packages PR (because `pnpm changeset status` exits 0 both for "pending changesets" and for "nothing to do"). The follow-up `pnpm changeset version` then failed with "No unreleased changesets found" because the changesets had already been consumed by the Version Packages PR.

2. **`backmerge.yml` `open-backmerge` job** failed every time with `fatal: ambiguous argument 'origin/staging': unknown revision or path not in the working tree` because the checkout uses `fetch-depth: 1`, so `origin/staging` is not fetched.

## What this PR does

### `publish.yml`

Replace the inverted-exit-code check with a JSON output check:

```yaml
pnpm changeset status --output status.json >/dev/null
RELEASES=$(node -e "const p=require('./status.json'); console.log((p.changesets||[]).reduce((n,c)=>n+(c.releases||[]).length,0))")
if [ "$RELEASES" -gt 0 ]; then
  echo "has_changesets=true" >> "$GITHUB_OUTPUT"
else
  echo "has_changesets=false" >> "$GITHUB_OUTPUT"
fi
```

`has_changesets` is true only when there is at least one release to publish. This is the correct semantics: if there are no changesets, there's nothing to do, so the rest of the pipeline should skip.

### `backmerge.yml`

Add a fetch step before the SHA comparison:

```yaml
- name: Fetch origin/staging
  run: git fetch origin staging:refs/remotes/origin/staging
```

This makes `origin/staging` available for `git rev-parse` and the SHA comparison.

## Why this matters

These two bugs were latent since PR #394. The pipeline never completed a 1.2.0 release because:

1. PR #394 merged a complex PR that included many changesets. The "backmerge" merges added more changesets. The bump would have been 1.1.0 → 1.1.2.
2. The detect bug means: the *first* time publish.yml fires on a fresh main branch (no changesets), it incorrectly proceeds and tries to bump — fails. The *second* time (after a real Version Packages PR has been merged) it correctly detects no changesets and skips.
3. The backmerge bug means: staging never gets back-merged from main automatically. Every merge to main required a manual backmerge PR (the four we've opened: #396, #399, #401, #403).

Both bugs are caught by the e2e test that PR #404 finally ran end-to-end.

## Verification

After merge:
- `publish.yml` on the next PR merge into main correctly evaluates `has_changesets` based on JSON output, not exit code.
- `backmerge.yml` correctly fetches `origin/staging` and opens a backmerge PR after each successful publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)