### PR TITLE
chore: back-merge main -> staging (PR #405 publish.yml + backmerge.yml fixes)

### DIFF
--- a/.changeset/backmerge-cli-v3.md
+++ b/.changeset/backmerge-cli-v3.md
@@ -1,5 +1,0 @@
----
-"@deessejs/fp": patch
----
-
-Back-merge of main to staging, bringing the changesets CLI v3 upgrade (PR #400) onto staging. The CLI was bumped from 2.31.0 to 3.0.0-next.5 to be compatible with changesets/action@v2.0.0-next.4. With this, the changesets-version.yml workflow should now run end-to-end and open a Version Packages PR against main on the next staging push.

--- a/.changeset/backmerge-fix-v2-action.md
+++ b/.changeset/backmerge-fix-v2-action.md
@@ -1,5 +1,0 @@
----
-"@deessejs/fp": patch
----
-
-Back-merge of main to staging, bringing the changesets/action@v2.0.0-next.4 fix from PR #398 onto staging. With this, the changesets-version.yml workflow can resolve the action correctly and the Version Packages PR opens against main as designed.

--- a/.changeset/backmerge-format-fix.md
+++ b/.changeset/backmerge-format-fix.md
@@ -1,5 +1,0 @@
----
-"@deessejs/fp": patch
----
-
-Back-merge of main to staging, bringing the format: false fix from PR #402. Without this, changesets v3 tries to invoke prettier (not in devDependencies) and the format step fails. With format: false, the Version Packages PR pipeline runs end-to-end.

--- a/.changeset/backmerge-publish-detect-fix.md
+++ b/.changeset/backmerge-publish-detect-fix.md
@@ -1,0 +1,5 @@
+---
+"@deessejs/fp": patch
+---
+
+Back-merge of main to staging, bringing the publish.yml detect logic fix from PR #405. The detect job now uses --output JSON to count releases, so it correctly returns false when there are no changesets (e.g. on the merge commit of a Version Packages PR). The backmerge.yml now fetches origin/staging before reading it. After this lands, the pipeline should not regress on the next release.

--- a/.changeset/bootstrap-staging.md
+++ b/.changeset/bootstrap-staging.md
@@ -1,6 +1,0 @@
----
-"@deessejs/fp": patch
----
-
-Bootstrap changeset for the back-merge of main onto staging. The new release pipeline (5-job publish, changesets-version.yml, backmerge.yml, ci.yml with changeset-check) now lives on staging. This PR carries no functional change; the changeset exists solely to satisfy the per-PR Changeset rule.
-After this PR merges, the Changeset file will be consumed by changesets-version.yml, producing a 1.1.3 patch entry (or whatever the next version is) that documents this bootstrap in the CHANGELOG.

--- a/.changeset/e2e-pipeline-test-2.md
+++ b/.changeset/e2e-pipeline-test-2.md
@@ -1,6 +1,0 @@
----
-"@deessejs/fp": patch
----
-
-End-to-end test of the new release pipeline on staging after the back-merge. This PR validates that changeset-check passes, that changesets-version.yml opens the Version Packages PR against main on merge, that publish.yml runs end-to-end, and that backmerge.yml keeps staging in sync.
-No functional change to the library.

--- a/.changeset/release-1.1.0.md
+++ b/.changeset/release-1.1.0.md
@@ -1,7 +1,0 @@
----
-"@deessejs/fp": minor
----
-
-Release 1.1.0.
-
-Advances the version from 1.0.2 (the dummy release-test artifact) to 1.1.0 to bring the published version on npm into a clean state. The release pipeline is now end-to-end validated; this entry produces the first legitimate user-facing minor bump since the Trusted Publishing migration.

--- a/.github/workflows/backmerge.yml
+++ b/.github/workflows/backmerge.yml
@@ -40,6 +40,9 @@ jobs:
           ref: main
           fetch-depth: 1
 
+      - name: Fetch origin/staging
+        run: git fetch origin staging:refs/remotes/origin/staging
+
       - name: Check if backmerge is needed
         id: check
         run: |

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -65,18 +65,21 @@ jobs:
       - name: Run pnpm changeset status
         id: status
         run: |
-          # `pnpm changeset status` exits 0 on the happy path: when
-          # changesets ARE pending (it successfully reports their
-          # status). It exits non-zero only when packages changed but
-          # no changeset is present, which is a config error. We
-          # invert the exit code: 0 means "proceed".
-          if pnpm changeset status; then
+          # `pnpm changeset status` exits 0 in two cases:
+          # (a) pending changesets exist, or (b) nothing to do.
+          # Exit 1 only on a config error. Since exit code alone is
+          # ambiguous, we use --output to dump the release plan and
+          # count releases in the changesets array.
+          pnpm changeset status --output status.json >/dev/null
+          RELEASES=$(node -e "const p=require('./status.json'); console.log((p.changesets||[]).reduce((n,c)=>n+(c.releases||[]).length,0))")
+          if [ "$RELEASES" -gt 0 ]; then
             echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "Pending changesets found — proceeding with release."
+            echo "Pending changesets found ($RELEASES releases) — proceeding with release."
           else
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
             echo "No pending changesets — skipping release."
           fi
+          rm -f status.json
 
   push-bump:
     name: Bump and push version to main

--- a/packages/fp/CHANGELOG.md
+++ b/packages/fp/CHANGELOG.md
@@ -1,5 +1,23 @@
 # @deessejs/fp
 
+## 1.2.0
+
+### Minor Changes
+
+- 04e3798: Release 1.1.0.
+  
+  Advances the version from 1.0.2 (the dummy release-test artifact) to 1.1.0 to bring the published version on npm into a clean state. The release pipeline is now end-to-end validated; this entry produces the first legitimate user-facing minor bump since the Trusted Publishing migration.
+
+### Patch Changes
+
+- 2814283: Back-merge of main to staging, bringing the changesets CLI v3 upgrade (PR #400) onto staging. The CLI was bumped from 2.31.0 to 3.0.0-next.5 to be compatible with changesets/action@v2.0.0-next.4. With this, the changesets-version.yml workflow should now run end-to-end and open a Version Packages PR against main on the next staging push.
+- 97a72be: Back-merge of main to staging, bringing the changesets/action@v2.0.0-next.4 fix from PR #398 onto staging. With this, the changesets-version.yml workflow can resolve the action correctly and the Version Packages PR opens against main as designed.
+- 9b6e5b5: Back-merge of main to staging, bringing the format: false fix from PR #402. Without this, changesets v3 tries to invoke prettier (not in devDependencies) and the format step fails. With format: false, the Version Packages PR pipeline runs end-to-end.
+- 6e3b4fc: Bootstrap changeset for the back-merge of main onto staging. The new release pipeline (5-job publish, changesets-version.yml, backmerge.yml, ci.yml with changeset-check) now lives on staging. This PR carries no functional change; the changeset exists solely to satisfy the per-PR Changeset rule.
+  After this PR merges, the Changeset file will be consumed by changesets-version.yml, producing a 1.1.3 patch entry (or whatever the next version is) that documents this bootstrap in the CHANGELOG.
+- a59f5d1: End-to-end test of the new release pipeline on staging after the back-merge. This PR validates that changeset-check passes, that changesets-version.yml opens the Version Packages PR against main on merge, that publish.yml runs end-to-end, and that backmerge.yml keeps staging in sync.
+  No functional change to the library.
+
 ## 1.1.2
 
 ### Patch Changes

--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.1.2",
+  "version": "1.2.0",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
One-time back-merge to bring PR #405 (the publish.yml detect fix and backmerge.yml fetch fix) onto staging. After merge, the pipeline should not regress on the next release.