### PR TITLE
chore: full end-to-end test of the release pipeline

### DIFF
--- a/.changeset/full-e2e-test.md
+++ b/.changeset/full-e2e-test.md
@@ -1,0 +1,6 @@
+---
+"@deessejs/fp": patch
+---
+
+Full end-to-end test of the release pipeline. Validates that changesets-version.yml opens a Version Packages PR against main after this changeset is merged into staging, that publish.yml runs end-to-end and publishes 1.1.3 to npm via Trusted Publishing (OIDC), and that backmerge.yml opens a backmerge PR from main to staging.
+No functional change to the library.


### PR DESCRIPTION
Dummy PR to test the end-to-end pipeline. The changeset file is the only change. After merge, changesets-version.yml should open a Version Packages PR against main.