### PR TITLE
fix(publish): detect version bump in merge commit instead of changesets

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -93,20 +93,19 @@ jobs:
             exit 0
           fi
 
-          # PR merge: check whether the merge commit introduced
-          # changeset files under .changeset/. If yes, the merge
-          # brought a release-worthy change into main and we
-          # should bump + publish.
-          CHANGED=$(git diff --name-only HEAD~1 HEAD \
-            | grep -E '^\.changeset/.*\.md$' \
-            | grep -v 'README.md$' \
-            | wc -l)
-          if [ "$CHANGED" -gt 0 ]; then
+          # PR merge: the changesets-version.yml workflow bumps
+          # packages/fp/package.json on its branch and deletes the
+          # changesets. After the merge, the changesets are gone
+          # but the version bump persists. So we detect a release
+          # by checking whether packages/fp/package.json changed
+          # in HEAD~1..HEAD.
+          if git diff --name-only HEAD~1 HEAD -- 'packages/fp/package.json' | grep -q .; then
             echo "has_changesets=true" >> "$GITHUB_OUTPUT"
-            echo "$CHANGED changeset(s) introduced by the merge."
+            VERSION=$(node -p "require('./packages/fp/package.json').version")
+            echo "Version bump detected in merge commit: $VERSION"
           else
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
-            echo "No changesets in the merge — skipping release."
+            echo "No version bump in packages/fp/package.json — skipping release."
           fi
 
       - name: Bump versions


### PR DESCRIPTION
Fixes the skip path bug in `publish.yml`. PR #407 and PR #409 (both Version Packages PRs from `changeset-release/main`) merged into main, but `publish.yml` detected no changesets and skipped the publish step.

## What this PR does

Replaces the changeset-presence detection with a version-bump detection:

```bash
# Before
CHANGED=$(git diff --name-only HEAD~1 HEAD \
  | grep -E '^\.changeset/.*\.md$' \
  | grep -v 'README.md$' \
  | wc -l)
if [ "$CHANGED" -gt 0 ]; then
  echo "has_changesets=true" >> "$GITHUB_OUTPUT"
fi

# After
if git diff --name-only HEAD~1 HEAD -- 'packages/fp/package.json' | grep -q .; then
  echo "has_changesets=true" >> "$GITHUB_OUTPUT"
fi
```

## Why this matters

`changesets-version.yml` opens a Version Packages PR after a staging merge. That PR's branch bumps `packages/fp/package.json` and deletes the changesets. When the Version Packages PR merges into main:

- The merge commit has the **bumped version** in `package.json`.
- The merge commit has **no changesets** (they were consumed on the bot's branch).

The previous logic checked for changesets → found none → skipped the publish. The result: no release ever happens for version-bump PRs.

## Verification

After merge, the next Version Packages PR merge will:
1. Detect `package.json` change → `has_changesets=true`.
2. Run `Bump versions`, `Push version bump back to main`, `validate`, `Publish packages`, `Create git tag`, `Create GitHub Release`.
3. Publish the new version to npm via Trusted Publishing (OIDC).
4. `backmerge.yml` opens a backmerge PR to staging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)