### PR TITLE
chore: bump version to 1.2.2 (test publish trigger)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Dummy PR that bumps packages/fp/package.json from 1.2.1 to 1.2.2. The PR is intended to test that publish.yml now correctly detects the version bump (post-PR #410) and runs the full publish chain.