### PR TITLE
fix(publish): remove duplicate fi that broke detect script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -87,7 +87,7 @@ jobs:
           else
             echo "has_changesets=false" >> "$GITHUB_OUTPUT"
             echo "No version bump in packages/fp/package.json — skipping release."
-          fi          fi
+          fi
           rm -f status.json
 
   push-bump:


### PR DESCRIPTION
The PR #410 trigger fix produced a detect script with 'fi          fi' on one line. That double-fi makes the shell error out on parsing, so has_changesets is never set and the rest of the job skips silently.

## What this PR does

Single-character fix: remove the duplicate fi.

## Why this matters

PR #411 (a version bump from 1.2.1 to 1.2.2) was merged to test the new detect logic. The publish.yml workflow fired on the merge commit. The detect step "completed" but has_changesets=false was set, so the publish job never ran. Without this fix, the new detect logic is unreachable.