### PR TITLE
chore: bump version to 1.2.3 (final publish trigger test)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Dummy PR that bumps packages/fp/package.json from 1.2.2 to 1.2.3 to validate the post-PR-413 fix to publish.yml. After this merges, publish.yml should detect the version bump and run the full chain (validate, publish, release).