### PR TITLE
chore: bump version to 1.2.4 (final publish test)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.3",
+  "version": "1.2.4",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Test PR. The v1.2.3 tag has now been pushed to origin. This new bump to 1.2.4 should pass the tag-already-exists guard and complete the full publish chain (validate, publish, release).