### PR TITLE
chore: bump version to 1.2.5 (validate force-tag fix from #418)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.4",
+  "version": "1.2.5",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Test PR for the force-tag fix from issue #418. After merge, publish.yml should:
1. Force-create the v1.2.5 tag (no more tag-already-exists guard).
2. Create a GitHub Release with auto-generated release notes.