### PR TITLE
chore: bump version to 1.2.6 (validate tag_name fix from #421)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.5",
+  "version": "1.2.6",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Test PR for the tag_name step output fix. After merge, publish.yml should create a real v1.2.6 GitHub Release (not the literal unexpanded string).