### PR TITLE
fix(publish): quote the resolve-version run block to avoid shell parse error

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -185,7 +185,8 @@ jobs:
 
       - name: Resolve version
         id: version
-        run: echo "tag=v$(node -p \"require('./packages/fp/package.json').version\")" >> "$GITHUB_OUTPUT"
+        run: |
+          echo "tag=v$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
 
       - name: Create or update git tag (idempotent)
         run: |


### PR DESCRIPTION
Follow-up to PR #421. The original resolve-version step used `\"` escapes inside an inline `run:` string, which the runner's shell parses as three separate quoted regions. The resulting syntax error breaks the resolve-version step, which prevents the GitHub Release from being created.

## The bug

```yaml
- name: Resolve version
  id: version
  run: echo "tag=v$(node -p \"require('./packages/fp/package.json').version\")" >> "$GITHUB_OUTPUT"
```

The escaped `\"` produces:
- `echo "tag=v` (open quote)
- `$(node -p "require('./packages/fp/package.json').version"` (subshell with its own double-quoted argument)
- `)` (subshell close)
- `")" >> "$GITHUB_OUTPUT"` (close outer quote + redirect)

The middle region has unescaped `"` which the shell sees as quote terminators, breaking the command.

## Fix

Use a block scalar with single-quoted outer wrapper and double-quoted JSON key:

```yaml
- name: Resolve version
  id: version
  run: |
    echo "tag=v$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
```

The block scalar preserves the full multi-character string. The single quotes around `'require(...)'` let the inner double quotes pass through unchanged.

## Verification

After merge and on the next version bump, the resolve-version step should:
1. Run `node -p` against `packages/fp/package.json`.
2. Output the version in `tag=vX.Y.Z` format.
3. Export it via `$GITHUB_OUTPUT` as a step output named `tag`.
4. Be referenced by `tag_name: v${{ steps.version.outputs.tag }}` in the softprops/action-gh-release step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)