### PR TITLE
fix(publish): remove unnecessary escape in resolve-version script

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          echo "tag=v$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
+          echo "tag=v$(node -p 'require("./packages/fp/package.json").version')" >> "$GITHUB_OUTPUT"
 
       - name: Create or update git tag (idempotent)
         run: |


### PR DESCRIPTION
Follow-up to PR #423. The single-quoted node argument still had escaped double quotes (`\\\"`), which the shell passed through to node. node interpreted `\\\".` as an invalid unicode escape and threw `SyntaxError: Expected unicode escape`.

## The bug

```yaml
run: |
  echo "tag=v$(node -p 'require(\\\"./packages/fp/package.json\\\").version')" >> "$GITHUB_OUTPUT"
```

After YAML and shell parsing, node receives the string:
```
require(\"./packages/fp/package.json\").version
```

JS parses `\".` as an escape sequence, fails because `\.` is not a valid escape, throws SyntaxError.

## Fix

Use the original double-quoted path inside single quotes — no escaping needed because the YAML block scalar preserves the content as-is, and the shell preserves the inner double quotes inside single quotes:

```yaml
run: |
  echo "tag=v$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
```

After YAML and shell parsing, node sees:
```js
require("./packages/fp/package.json").version
```

Which is valid JS.

## Verification

After merge and on the next version bump:
1. `Resolve version` step succeeds and exports `tag=vX.Y.Z`.
2. `Create or update git tag` correctly tags `vX.Y.Z` (already working).
3. `Create GitHub Release` step reads `tag_name: v${{ steps.version.outputs.tag }}` and creates the real release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)