### PR TITLE
chore: bump version to 1.2.8 (final e2e test)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.7",
+  "version": "1.2.8",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Test PR for the escape fix from PR #425. Should now create a real v1.2.8 GitHub Release.