### PR TITLE
fix(publish): drop v prefix from resolve-version output

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -186,7 +186,7 @@ jobs:
       - name: Resolve version
         id: version
         run: |
-          echo "tag=v$(node -p 'require("./packages/fp/package.json").version')" >> "$GITHUB_OUTPUT"
+          echo "tag=$(node -p 'require("./packages/fp/package.json").version')" >> "$GITHUB_OUTPUT"
 
       - name: Create or update git tag (idempotent)
         run: |


### PR DESCRIPTION
Follow-up to PR #425. The resolve-version step outputs `tag=v1.2.8` (with the `v` prefix), and `tag_name: v${{ steps.version.outputs.tag }}` becomes `vv1.2.8`. Drop the `v` prefix from the resolve-version output so the tag is correct.

## The bug

```yaml
- name: Resolve version
  id: version
  run: |
    echo "tag=v$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
```

The `tag` output is `v1.2.8`. Then `${{ steps.version.outputs.tag }}` resolves to `v1.2.8`. Combined with `tag_name: v${{ steps.version.outputs.tag }}`, the final tag is `vv1.2.8`.

## Fix

```yaml
- name: Resolve version
  id: version
  run: |
    echo "tag=$(node -p 'require(\"./packages/fp/package.json\").version')" >> "$GITHUB_OUTPUT"
```

The `tag` output is now `1.2.8`. The `tag_name: v${{ steps.version.outputs.tag }}` becomes `v1.2.8`.

## Verification

After merge and on the next version bump:
1. The `resolve-version` step succeeds and outputs `tag=1.2.8`.
2. The `tag_name` is `v1.2.8`.
3. The GitHub Release is created at `v1.2.8` (not `vv1.2.8`).

## Side effect

The previous run created a `vv1.2.8` release at https://github.com/deessejs/fp/releases/tag/vv1.2.8. After this fix, the next release with `force-tag` will overwrite the `vv1.2.8` tag with `v1.2.8` (the force-tag is intentional). The release entry will be updated to reflect the new tag's commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)