### PR TITLE
chore: bump version to 1.2.9 (final e2e test)

### DIFF
--- a/packages/fp/package.json
+++ b/packages/fp/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@deessejs/fp",
-  "version": "1.2.8",
+  "version": "1.2.9",
   "description": "Functional Programming Utilities for TypeScript",
   "homepage": "https://fp.deessejs.com",
   "repository": {


### PR DESCRIPTION
Test PR for the v-prefix fix from PR #427. Should now create a real v1.2.9 GitHub Release (not vv1.2.9).